### PR TITLE
Make skygear easier to include in a webpack project

### DIFF
--- a/lib/pubsub.js
+++ b/lib/pubsub.js
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 const _ = require('lodash');
-const WebSocket = require('websocket').w3cwebsocket;
+const _ws = require('websocket');
+let WebSocket = null;
+if (_ws) {
+  WebSocket = _ws.w3cwebsocket;
+} else {
+  WebSocket = window.WebSocket; //eslint-disable-line
+}
 const url = require('url');
 const ee = require('event-emitter');
 

--- a/package.json
+++ b/package.json
@@ -61,15 +61,15 @@
     "babel-polyfill": "^6.1.19",
     "cookie-storage": "^1.0.4",
     "event-emitter": "^0.3.4",
-    "localforage": "~1.2.10",
     "localstorage-memory": "^1.0.2",
+    "localforage": "^1.4.2",
     "lodash": "^3.10.1",
     "md5": "^2.0.0",
     "superagent": "^1.3.0",
     "url": "^0.11.0",
     "uuid": "^2.0.1",
     "w3c-blob": "0.0.1",
-    "websocket": "^1.0.22"
+    "websocket": "^1.0.23"
   },
   "bugs": {
     "url": "https://github.com/SkygearIO/skygear-SDK-JS/issues"


### PR DESCRIPTION
localforage to 1.4.2, it support es6 and webpack since 1.3.3
Use browser WebSocket if websocket is not install, it allow webpack to
configure to use browser WebSocket if set 'websocket' as external.