### PR TITLE
Make the asset toJSON and fromJSON mirror on $url key

### DIFF
--- a/lib/asset.js
+++ b/lib/asset.js
@@ -55,7 +55,8 @@ export default class Asset {
   toJSON() {
     return {
       $type: 'asset',
-      $name: this.name
+      $name: this.name,
+      $url: this.url
     };
   }
 

--- a/test/asset.js
+++ b/test/asset.js
@@ -32,11 +32,12 @@ describe('Asset', function () {
   it('serializes to JSON', function () {
     let asset = new Asset({
       name: 'asset-name',
-      url: 'http://you-shalt-not-see.me/'
+      url: 'http://server-will-ignore.me/'
     });
     expect(asset.toJSON()).to.eql({
       $type: 'asset',
-      $name: 'asset-name'
+      $name: 'asset-name',
+      $url: 'http://server-will-ignore.me/'
     });
   });
 
@@ -50,5 +51,14 @@ describe('Asset', function () {
     expect(asset.url).to.equal('http://skygear.dev/files/asset-name?expiredAt=1446034750&signature=signature');
   });
 
+  it('serializes and deserializes is mirror', function () {
+    let resp = {
+      $type: 'asset',
+      $name: 'asset-name',
+      $url: 'http://skygear.dev/files/asset-name?expiredAt=1446034750\u0026signature=signature'
+    };
+    let asset = Asset.fromJSON(resp);
+    expect(asset.toJSON()).eql(resp);
+  });
 });
 /*eslint-enable max-len, no-new */


### PR DESCRIPTION
Since skygear-server deserialization is ignoring extra key ($url here),
it is safe to include it in the record playload.
connects  #10