### PR TITLE
cloud: Fix undefined result with no event handlers

### DIFF
--- a/lib/cloud/transport/common.js
+++ b/lib/cloud/transport/common.js
@@ -180,7 +180,9 @@ export default class CommonTransport {
 
     if (!funcList) {
       // It is okay that the sending event has no handlers
-      return Promise.resolve();
+      return Promise.resolve({
+        result: []
+      });
     }
 
     const funcPromises = funcList.map(

--- a/test/cloud/transport/common.js
+++ b/test/cloud/transport/common.js
@@ -110,6 +110,24 @@ describe('CommonTransport', function () {
     });
   });
 
+  it('should return empty array if no event handlers', function (done) {
+    const registry = new Registry();
+
+    const transport = new CommonTransport(registry);
+    return transport.eventHandler({
+      kind: 'event',
+      name: 'hello',
+      param: {
+        hello: 'world'
+      }
+    }).then((result) => {
+      expect(result).to.be.eql({
+        result: []
+      });
+      done();
+    }).catch(done);
+  });
+
   it('should call with timerHandler', function (done) {
     const registry = new Registry();
     const timerFunc = sinon.spy();


### PR DESCRIPTION
CommoonTransport resolve a promise with an undefined result if no
event handlers are defined. This will cause the HTTP transport
to write undefined to ServerResponse, which is not allowed.