### PR TITLE
Fix crash when container.cacheResponse setter is accessed

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -566,8 +566,12 @@ export default class Container {
   set cacheResponse(value) {
     const b = !!value;
     this._cacheResponse = b;
-    this.publicDB.cacheResponse = b;
-    this.privateDB.cacheResponse = b;
+    if (this._publicDB) {
+      this._publicDB.cacheResponse = b;
+    }
+    if (this._privateDB) {
+      this._privateDB.cacheResponse = b;
+    }
   }
 
   _getUser() {
@@ -678,6 +682,7 @@ export default class Container {
   get publicDB() {
     if (this._publicDB === null) {
       this._publicDB = new Database('_public', this);
+      this._publicDB.cacheResponse = this._cacheResponse;
     }
     return this._publicDB;
   }
@@ -688,6 +693,7 @@ export default class Container {
     }
     if (this._privateDB === null) {
       this._privateDB = new Database('_private', this);
+      this._privateDB.cacheResponse = this._cacheResponse;
     }
     return this._privateDB;
   }

--- a/test/container.js
+++ b/test/container.js
@@ -36,14 +36,34 @@ describe('Container', function () {
     expect(container.cacheResponse).to.be.true();
   });
 
+  it('does not eagerly initialize db when setting cacheResponse', function () {
+    let container = new Container();
+    container.autoPubsub = false;
+
+    container.cacheResponse = false;
+    expect(container._publicDB).to.be.null();
+    expect(container._privateDB).to.be.null();
+  });
+
+  it('initializes db with current cacheResponse setting', function () {
+    let container = new Container();
+    container.autoPubsub = false;
+
+    container.cacheResponse = false;
+    expect(container._publicDB).to.be.null();
+    expect(container._privateDB).to.be.null();
+
+    expect(container.publicDB.cacheResponse).to.be.false();
+
+    container._accessToken = 'access-token';
+    expect(container.privateDB.cacheResponse).to.be.false();
+  });
+
   it('forwards cacheResponse to its databases', function () {
     let container = new Container();
     container.autoPubsub = false;
-    container._accessToken = 'dummy-access-token-to-enable-private-db';
-
     container.cacheResponse = false;
-    expect(container.publicDB.cacheResponse).to.be.false();
-    expect(container.privateDB.cacheResponse).to.be.false();
+    container._accessToken = 'dummy-access-token-to-enable-private-db';
 
     container.cacheResponse = true;
     expect(container.publicDB.cacheResponse).to.be.true();
@@ -52,6 +72,10 @@ describe('Container', function () {
     container.cacheResponse = false;
     expect(container.publicDB.cacheResponse).to.be.false();
     expect(container.privateDB.cacheResponse).to.be.false();
+
+    container.cacheResponse = true;
+    expect(container.publicDB.cacheResponse).to.be.true();
+    expect(container.privateDB.cacheResponse).to.be.true();
   });
 
   it('should clear access token on 104 AccessTokenNotAccepted', function () {


### PR DESCRIPTION
connect #76 

Sorry for this silly bug.