### PR TITLE
Fix not able to create Record with `id` attr

### DIFF
--- a/lib/record.js
+++ b/lib/record.js
@@ -92,6 +92,7 @@ export default class Record {
       }
       id = name;
     }
+    delete attrs.id; // because `id` is a readonly property
     this._id = id;
     this._access = Record.defaultACL;
     this.update(attrs);

--- a/test/record.js
+++ b/test/record.js
@@ -95,6 +95,15 @@ describe('Extended Record', function () {
     expect(r._id).to.equal('1');
   });
 
+  it('accept id with type', function () {
+    let r = new Note({
+      id: 'note/1'
+    });
+    expect(r.id).to.equal('note/1');
+    expect(r.recordType).to.equal('note');
+    expect(r._id).to.equal('1');
+  });
+
   it('reject _id with different type', function () {
     expect(function () {
       let r = new Note({


### PR DESCRIPTION
The constructor of Record prefers `id` to pass record ID, but it is not
possible to use this attr as the update function will set the record ID
to `id` property, which is readonly.

Not having this change will result in TypeError:

```
TypeError: Cannot set property id of #<Record> which has only a getter
```