### PR TITLE
Fix binary static asset encoding

### DIFF
--- a/lib/cloud/asset.js
+++ b/lib/cloud/asset.js
@@ -37,7 +37,6 @@ export function staticAssetHandler(req) {
     });
   }
   const data = fs.readFileSync(finalPath, {
-    encoding: 'utf8',
     flag: 'r'
   });
   const contentType = mime.contentType(path.extname(finalPath));

--- a/lib/cloud/transport/common.js
+++ b/lib/cloud/transport/common.js
@@ -26,13 +26,19 @@ import Record from '../../record';
 import skyconfig from '../skyconfig';
 
 /**
- * Encode 16-bit unicode strings to base64 string.
+ * Encode 16-bit unicode strings or a buffer to base64 string.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem
  */
-function b64EncodeUnicode(str) {
+function b64EncodeUnicode(data) {
+  // If the data is a buffer, use its base64 encoding instead of using
+  // our unicode to base64 encoding.
+  if (data instanceof Buffer) {
+    return data.toString('base64');
+  }
+
   return btoa(
-    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
+    encodeURIComponent(data).replace(/%([0-9A-F]{2})/g,
     function (match, p1) {
       return String.fromCharCode('0x' + p1);
     })


### PR DESCRIPTION
The existing implementation cannot send binary static asset through
a handler. The new static asset handler returns a buffer so that
that the transport layer uses the buffer's base64 encoding to fix this problem.