### PR TITLE
Accept arguments to create profile when creating user

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -120,6 +120,20 @@ export default class Container {
     return this._signup(null, email, password);
   }
 
+  signupWithUsernameAndProfile(username, password, profile = {}) {
+    return this.signupWithUsername(username, password)
+    .then((user)=>
+      this._createProfile(user, profile)
+    );
+  }
+
+  signupWithEmailAndProfile(email, password, profile = {}) {
+    return this.signupWithEmail(email, password)
+    .then((user)=>
+      this._createProfile(user, profile)
+    );
+  }
+
   signupAnonymously() {
     return this._signup(null, null, null);
   }
@@ -133,6 +147,14 @@ export default class Container {
         password: password
       }).then(container._authResolve.bind(container)).then(resolve, reject);
     });
+  }
+
+  _createProfile(user, profile) {
+    let record = new this.UserRecord({
+      _id: 'user/' + user.id,
+      ...profile
+    });
+    return this.publicDB.save(record);
   }
 
   _authResolve(body) {

--- a/test/container.js
+++ b/test/container.js
@@ -349,6 +349,46 @@ describe('Container auth', function () {
       });
   });
 
+  it('should signup with profile successfully', function () {
+    return container
+      .signupWithUsernameAndProfile('username', 'passwd', {
+        'key': 'value'
+      })
+      .then(function (profile) {
+        assert.equal(
+          container.accessToken,
+          'uuid1');
+        assert.instanceOf(container.currentUser, container.User);
+        assert.equal(
+          container.currentUser.id,
+          'user:id1'
+        );
+        assert.equal(profile.key, 'value');
+      }, function () {
+        throw new Error('Signup failed');
+      });
+  });
+
+  it('should signup with email and profile successfully', function () {
+    return container
+      .signupWithEmailAndProfile('user@email.com', 'passwd', {
+        'key': 'value'
+      })
+      .then(function (profile) {
+        assert.equal(
+          container.accessToken,
+          'uuid1');
+        assert.instanceOf(container.currentUser, container.User);
+        assert.equal(
+          container.currentUser.id,
+          'user:id1'
+        );
+        assert.equal(profile.key, 'value');
+      }, function () {
+        throw new Error('Signup failed');
+      });
+  });
+
   it('should signup anonymously', function () {
     return container
       .signupAnonymously()

--- a/test/database.js
+++ b/test/database.js
@@ -61,7 +61,21 @@ let request = mockSuperagent([{
     let records = params['records'];
     let firstRecord = records[0];
     if (records.length === 1) {
-      if (params['database_id'] === '_public' &&
+      if (firstRecord._id.indexOf('user/') === 0) {
+        return fn({
+          'result': [{
+            '_type': 'record',
+            '_created_at': '2014-09-27T17:40:00.000Z',
+            '_ownerID': 'rick.mak@gmail.com',
+            '_access': null,
+            '_transient': {
+              'synced': true,
+              'syncDate': {$type: 'date', $date: '2014-09-27T17:40:00.000Z'}
+            },
+            ...firstRecord
+          }]
+        });
+      } else if (params['database_id'] === '_public' &&
       firstRecord['_id'] === 'note/failed-to-save') {
         return fn({
           'result': [{


### PR DESCRIPTION
connect https://github.com/SkygearIO/skygear-server/issues/54

I guess there would be comments on how the API looks and I have to update few times anyway, so I won't work on other platforms until this is confirmed ok.

Added arguments to these 2 APIs.
```
singupWithUsername(username, password, {
  name: "some name"
}).then(([user, profile])=> { ... })
```
```
singupWithEmail(email, password, {
  name: "some name"
}).then(([user, profile])=> { ... })
```

And 2 new APIs:
```
singupWithUsernameAndProfiles(username, password, {
  "user": {
    name: "some name"
  },
  "private_user": {
    secret: ...
  }
}).then(([user, profile1, profile2])=> { ... })
```
```
singupWithEmailAndProfiles(email, password, {
  "user": {
    name: "some name"
  },
  "private_user": {
    secret: ...
  }
}).then(([user, profile1, profile2])=> { ... })
```

When a profile is supplied, the return value in promise becomes an array of `[user, ...profiles]`. This is because we are creating multiple records in database, and there is no clear relationship between `UserRecord` and `User`, I just want to follow the way it was, to separate them and therefore return them in an array. Any suggestion what should it be like?