### PR TITLE
Add pubsub.once helper function

### DIFF
--- a/lib/pubsub.js
+++ b/lib/pubsub.js
@@ -101,6 +101,25 @@ export default class Pubsub {
     return this.subscribe(channel, callback);
   }
 
+  /**
+   * Subscribe the channel once.
+   * This function takes one message off from a pubsub channel,
+   * returning a promise of that message.
+   *
+   * @param {string} channel Channel to listen on
+   * @return {Promise} Promise of next message in this channel
+   */
+  once(channel) {
+    const self = this;
+    return new Promise(function (resolve) {
+      function handler(data) {
+        self.unsubscribe(channel, handler);
+        resolve(data);
+      }
+      self.subscribe(channel, handler);
+    });
+  }
+
   publish(channel, data) {
     if (!channel) {
       throw new Error('Missing channel to publish');

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -194,6 +194,30 @@ describe('Pubsub', function () {
     expect(ws.send).to.be.calledOnce();
   });
 
+  it('once should subscribe channel and return promise', function () {
+    sinon.spy(pubsub, 'subscribe');
+    const promise = pubsub.once('CHANNEL');
+    promise.catch(function (err) {
+      throw err;
+    });
+    assert(pubsub.subscribe.calledOnce);
+    assert(promise instanceof Promise);
+  });
+
+  it('once should unsubscribe on message and resolve promise', function () {
+    ws.send = function () {};
+    sinon.spy(pubsub, 'unsubscribe');
+    const promise = pubsub.once('CHANNEL');
+    promise.catch(function (err) {
+      throw err;
+    });
+    ws.onmessage({data: '{"channel": "CHANNEL", "data": "DATA"}'});
+    assert(pubsub.unsubscribe.calledOnce);
+    promise.then(function (data) {
+      assert(data === 'DATA');
+    });
+  });
+
 });
 
 describe('Pubsub connection', function () {


### PR DESCRIPTION
Useful for working with ES7 async/await:
```js
async function foo() {
  await skygear.pubsub.once('bar');
  // ...
}
```