### PR TITLE
Fix auth provider not binding when calling `handleAction`

### DIFF
--- a/lib/cloud/transport/common.js
+++ b/lib/cloud/transport/common.js
@@ -314,7 +314,7 @@ export default class CommonTransport {
     }
 
     return this._promisify(
-      provider.handleAction,
+      provider.handleAction.bind(provider),
       param.action,
       param
     ).then((result) => {


### PR DESCRIPTION
This will cause a crash while auth providier will call
`this[action]` to get corresponding action method