### PR TITLE
Force asset collector to exit at the end

### DIFF
--- a/packages/skygear-core/lib/asset_collect.js
+++ b/packages/skygear-core/lib/asset_collect.js
@@ -52,3 +52,7 @@ Object.keys(registry.staticAsset).forEach(function (key) {
     console.log(`Copied ${src} into ${dest}`);
   });
 });
+
+// Force the process to exit because we might have imported code
+// that queued a callback.
+process.exit();


### PR DESCRIPTION
The node js process may not exit if imported js code queued a callback.