### PR TITLE
Support parameterized paths

### DIFF
--- a/packages/skygear-core/lib/cloud/registry.js
+++ b/packages/skygear-core/lib/cloud/registry.js
@@ -144,7 +144,7 @@ export class Registry {
 
   getHandler(path, method) {
     for (let k in this.handlers) {
-      if (this._matchHandler(k, path)) {
+      if (Registry._matchHandler(k, path)) {
         let func = this.handlers[k][method];
         func.handlerName = k;
         return func;
@@ -153,7 +153,7 @@ export class Registry {
     return undefined;
   }
 
-  _matchHandler(handlerName, path) {
+  static _matchHandler(handlerName, path) {
     const namePattern = new RegExp('^' + handlerName.replace(/\/:((?!\/).)+/g, '/((?!/).)+') + '$');
     return path.match(namePattern) !== null;
   }

--- a/packages/skygear-core/lib/cloud/registry.js
+++ b/packages/skygear-core/lib/cloud/registry.js
@@ -143,7 +143,13 @@ export class Registry {
   }
 
   getHandler(name, method) {
-    return this.handlers[name][method];
+    for (let k in this.handlers) {
+      const handlerPattern = /\/:((?!\/).)+/g;
+      const namePattern = new RegExp('^' + k.replace(handlerPattern, '/((?!/).)+') + '$');
+      if (name.match(namePattern) !== null)
+        return this.handlers[k][method];
+    }
+    return undefined;
   }
 
   getProvider(name) {

--- a/packages/skygear-core/lib/cloud/registry.js
+++ b/packages/skygear-core/lib/cloud/registry.js
@@ -154,7 +154,9 @@ export class Registry {
   }
 
   static _matchHandler(handlerName, path) {
-    const namePattern = new RegExp('^' + handlerName.replace(/\/:((?!\/).)+/g, '/((?!/).)+') + '$');
+    const namePattern = new RegExp(
+      '^' + handlerName.replace(/\/:((?!\/).)+/g, '/((?!/).)+') + '$'
+    );
     return path.match(namePattern) !== null;
   }
 

--- a/packages/skygear-core/lib/cloud/registry.js
+++ b/packages/skygear-core/lib/cloud/registry.js
@@ -144,30 +144,31 @@ export class Registry {
 
   getHandler(name, method) {
     for (let k in this.handlers) {
-      const handlerPattern = /\/:((?!\/).)+/g;
-      const namePattern = new RegExp('^' + k.replace(handlerPattern, '/((?!/).)+') + '$');
-      if (name.match(namePattern) !== null)
+      if (this._matchHandler(k, name))
         return this.handlers[k][method];
     }
     return undefined;
   }
 
-  parseParamsInUrl(url) {
+  parseParamsInPath(path) {
     for (let k in this.handlers) {
-      const handlerPattern = /\/:((?!\/).)+/g;
-      const namePattern = new RegExp('^' + k.replace(handlerPattern, '/((?!/).)+') + '$');
-      if (url.match(namePattern) !== null) {
+      if (this._matchHandler(k, path)) {
         let params = {};
         const handlerParts = k.split('/');
-        const urlParts = url.split('/');
+        const pathParts = path.split('/');
         for (let i = 0; i < handlerParts.length; i++) {
           if (handlerParts[i].startsWith(':'))
-            params[handlerParts[i].replace(':', '')] = urlParts[i];
+            params[handlerParts[i].replace(':', '')] = pathParts[i];
         }
         return params;
       }
     }
     return undefined;
+  }
+
+  _matchHandler(handlerName, path) {
+    const namePattern = new RegExp('^' + handlerName.replace(/\/:((?!\/).)+/g, '/((?!/).)+') + '$');
+    return path.match(namePattern) !== null;
   }
 
   getProvider(name) {

--- a/packages/skygear-core/lib/cloud/registry.js
+++ b/packages/skygear-core/lib/cloud/registry.js
@@ -142,25 +142,12 @@ export class Registry {
     return this._hookTypeMap[name];
   }
 
-  getHandler(name, method) {
-    for (let k in this.handlers) {
-      if (this._matchHandler(k, name))
-        return this.handlers[k][method];
-    }
-    return undefined;
-  }
-
-  parseParamsInPath(path) {
+  getHandler(path, method) {
     for (let k in this.handlers) {
       if (this._matchHandler(k, path)) {
-        let params = {};
-        const handlerParts = k.split('/');
-        const pathParts = path.split('/');
-        for (let i = 0; i < handlerParts.length; i++) {
-          if (handlerParts[i].startsWith(':'))
-            params[handlerParts[i].replace(':', '')] = pathParts[i];
-        }
-        return params;
+        let func = this.handlers[k][method];
+        func.handlerName = k;
+        return func;
       }
     }
     return undefined;

--- a/packages/skygear-core/lib/cloud/registry.js
+++ b/packages/skygear-core/lib/cloud/registry.js
@@ -152,6 +152,24 @@ export class Registry {
     return undefined;
   }
 
+  parseParamsInUrl(url) {
+    for (let k in this.handlers) {
+      const handlerPattern = /\/:((?!\/).)+/g;
+      const namePattern = new RegExp('^' + k.replace(handlerPattern, '/((?!/).)+') + '$');
+      if (url.match(namePattern) !== null) {
+        let params = {};
+        const handlerParts = k.split('/');
+        const urlParts = url.split('/');
+        for (let i = 0; i < handlerParts.length; i++) {
+          if (handlerParts[i].startsWith(':'))
+            params[handlerParts[i].replace(':', '')] = urlParts[i];
+        }
+        return params;
+      }
+    }
+    return undefined;
+  }
+
   getProvider(name) {
     return this.providers[name];
   }

--- a/packages/skygear-core/lib/cloud/transport/common.js
+++ b/packages/skygear-core/lib/cloud/transport/common.js
@@ -65,7 +65,7 @@ function b64DecodeUnicode(str) {
  * This is thin request object trying to provide a http.IncomingMessage like
  * object for access http request properties.
  */
-class SkygearRequest {
+export class SkygearRequest {
   constructor(param) {
     this.headers = param.header;
     this.method = param.method;
@@ -77,7 +77,7 @@ class SkygearRequest {
     } else {
       this.url = parse(`${this.path}`, true);
     }
-    this.params = param.params; //parameters in url
+    this.params = SkygearRequest._parseParamsInPath(param.handlerName, param.path)
   }
 
   get query() {
@@ -97,6 +97,17 @@ class SkygearRequest {
 
   get json() {
     return JSON.parse(this.body);
+  }
+
+  static _parseParamsInPath(handlerName, path) {
+    let params = {};
+    const handlerParts = handlerName.split('/');
+    const pathParts = path.split('/');
+    for (let i = 0; i < handlerParts.length; i++) {
+      if (handlerParts[i].startsWith(':'))
+        params[handlerParts[i].replace(':', '')] = pathParts[i+1];
+    }
+    return params;
   }
 }
 
@@ -382,9 +393,9 @@ export default class CommonTransport {
     if (!func) {
       return Promise.reject(new Error('Handler not exist'));
     }
-    param.params = this.registry.parseParamsInPath(name);
 
-    const options = { context };
+    param.handlerName = func.handlerName;
+    const options = {context};
     const req = new SkygearRequest(param);
     return this._promisify(
       func,

--- a/packages/skygear-core/lib/cloud/transport/common.js
+++ b/packages/skygear-core/lib/cloud/transport/common.js
@@ -77,6 +77,7 @@ class SkygearRequest {
     } else {
       this.url = parse(`${this.path}`, true);
     }
+    this.params = param.params; //parameters in url
   }
 
   get query() {
@@ -381,6 +382,7 @@ export default class CommonTransport {
     if (!func) {
       return Promise.reject(new Error('Handler not exist'));
     }
+    param.params = this.registry.parseParamsInUrl(name);
 
     const options = { context };
     const req = new SkygearRequest(param);

--- a/packages/skygear-core/lib/cloud/transport/common.js
+++ b/packages/skygear-core/lib/cloud/transport/common.js
@@ -77,7 +77,9 @@ export class SkygearRequest {
     } else {
       this.url = parse(`${this.path}`, true);
     }
-    this.params = SkygearRequest._parseParamsInPath(param.handlerName, param.path)
+    this.params = SkygearRequest._parseParamsInPath(
+      param.handlerName, param.path
+    );
   }
 
   get query() {
@@ -104,8 +106,9 @@ export class SkygearRequest {
     const handlerParts = handlerName.split('/');
     const pathParts = path.split('/');
     for (let i = 0; i < handlerParts.length; i++) {
-      if (handlerParts[i].startsWith(':'))
-        params[handlerParts[i].replace(':', '')] = pathParts[i+1];
+      if (handlerParts[i].startsWith(':')) {
+        params[handlerParts[i].replace(':', '')] = pathParts[i + 1];
+      }
     }
     return params;
   }

--- a/packages/skygear-core/lib/cloud/transport/common.js
+++ b/packages/skygear-core/lib/cloud/transport/common.js
@@ -382,7 +382,7 @@ export default class CommonTransport {
     if (!func) {
       return Promise.reject(new Error('Handler not exist'));
     }
-    param.params = this.registry.parseParamsInUrl(name);
+    param.params = this.registry.parseParamsInPath(name);
 
     const options = { context };
     const req = new SkygearRequest(param);

--- a/packages/skygear-core/test/cloud/registry.js
+++ b/packages/skygear-core/test/cloud/registry.js
@@ -115,6 +115,23 @@ describe('Registry', function () {
     expect(registry.getHandler('pubHandler', 'GET')).to.be.eql(pubHandler);
   });
 
+  it('add handler with parameters to funcList', function() {
+    const registry = new Registry();
+    function handlerWithParams() {}
+    registry.registerHandler('download/:platform/:version', handlerWithParams, {
+      method: ['GET'],
+      authRequired: false,
+      userRequired: true
+    });
+    expect(registry.funcList().handler).to.be.eql([{
+      name: 'download/:platform/:version',
+      methods: ['GET'],
+      auth_required: false,
+      user_required: true
+    }]);
+    expect(registry.getHandler('download/osx/1.0.0', 'GET')).to.be.eql(handlerWithParams);
+  });
+
   it('add static asset collect func', function () {
     const registry = new Registry();
     function staticAsset() {}

--- a/packages/skygear-core/test/cloud/registry.js
+++ b/packages/skygear-core/test/cloud/registry.js
@@ -149,45 +149,6 @@ describe('Registry', function () {
     expect(registry.getHandler('hello/foo/world/bar', 'GET')).to.be.eql(handlerWithParams);
   });
 
-  it('parse parameters in path', function() {
-    const registry = new Registry();
-    function handlerWithParams() {}
-    registry.registerHandler('download/:platform/:version', handlerWithParams, {
-      method: ['GET'],
-      authRequired: false,
-      userRequired: true
-    });
-    expect(registry.parseParamsInPath('download/osx/1.0.0')).to.be.deep.eql({
-      platform: 'osx',
-      version: '1.0.0'
-    });
-  });
-
-  it('parse parameters in path, calacala parameters', function() {
-    const registry = new Registry();
-    function handlerWithParams() {}
-    registry.registerHandler('hello/:param1/world/:param2', handlerWithParams, {
-      method: ['GET'],
-      authRequired: false,
-      userRequired: true
-    });
-    expect(registry.parseParamsInPath('hello/foo/world/bar')).to.be.deep.eql({
-      param1: 'foo',
-      param2: 'bar'
-    });
-  });
-
-  it('parse parameters in non parameterized path', function() {
-    const registry = new Registry();
-    function handlerWithParams() {}
-    registry.registerHandler('a/normal/url', handlerWithParams, {
-      method: ['GET'],
-      authRequired: false,
-      userRequired: true
-    });
-    expect(registry.parseParamsInPath('a/normal/url')).to.be.deep.eql({});
-  });
-
   it('add static asset collect func', function () {
     const registry = new Registry();
     function staticAsset() {}

--- a/packages/skygear-core/test/cloud/registry.js
+++ b/packages/skygear-core/test/cloud/registry.js
@@ -132,6 +132,23 @@ describe('Registry', function () {
     expect(registry.getHandler('download/osx/1.0.0', 'GET')).to.be.eql(handlerWithParams);
   });
 
+  it('add handler with parameters to funcList, calacala parameters', function() {
+    const registry = new Registry();
+    function handlerWithParams() {}
+    registry.registerHandler('hello/:param1/world/:param2', handlerWithParams, {
+      method: ['GET'],
+      authRequired: false,
+      userRequired: true
+    });
+    expect(registry.funcList().handler).to.be.eql([{
+      name: 'hello/:param1/world/:param2',
+      methods: ['GET'],
+      auth_required: false,
+      user_required: true
+    }]);
+    expect(registry.getHandler('hello/foo/world/bar', 'GET')).to.be.eql(handlerWithParams);
+  });
+
   it('parse parameters in url', function() {
     const registry = new Registry();
     function handlerWithParams() {}
@@ -144,6 +161,31 @@ describe('Registry', function () {
       platform: 'osx',
       version: '1.0.0'
     });
+  });
+
+  it('parse parameters in url, calacala parameters', function() {
+    const registry = new Registry();
+    function handlerWithParams() {}
+    registry.registerHandler('hello/:param1/world/:param2', handlerWithParams, {
+      method: ['GET'],
+      authRequired: false,
+      userRequired: true
+    });
+    expect(registry.parseParamsInUrl('hello/foo/world/bar')).to.be.deep.eql({
+      param1: 'foo',
+      param2: 'bar'
+    });
+  });
+
+  it('parse parameters in non parameterized url', function() {
+    const registry = new Registry();
+    function handlerWithParams() {}
+    registry.registerHandler('a/normal/url', handlerWithParams, {
+      method: ['GET'],
+      authRequired: false,
+      userRequired: true
+    });
+    expect(registry.parseParamsInUrl('a/normal/url')).to.be.deep.eql({});
   });
 
   it('add static asset collect func', function () {

--- a/packages/skygear-core/test/cloud/registry.js
+++ b/packages/skygear-core/test/cloud/registry.js
@@ -115,7 +115,7 @@ describe('Registry', function () {
     expect(registry.getHandler('pubHandler', 'GET')).to.be.eql(pubHandler);
   });
 
-  it('add handler with parameters to funcList', function() {
+  it('add handler with parameters to funcList', function () {
     const registry = new Registry();
     function handlerWithParams() {}
     registry.registerHandler('download/:platform/:version', handlerWithParams, {
@@ -129,10 +129,11 @@ describe('Registry', function () {
       auth_required: false,
       user_required: true
     }]);
-    expect(registry.getHandler('download/osx/1.0.0', 'GET')).to.be.eql(handlerWithParams);
+    expect(registry.getHandler('download/osx/1.0.0', 'GET'))
+      .to.be.eql(handlerWithParams);
   });
 
-  it('add handler with parameters to funcList, calacala parameters', function() {
+  it('add handler with alternating parameters to funcList', function () {
     const registry = new Registry();
     function handlerWithParams() {}
     registry.registerHandler('hello/:param1/world/:param2', handlerWithParams, {
@@ -146,23 +147,27 @@ describe('Registry', function () {
       auth_required: false,
       user_required: true
     }]);
-    expect(registry.getHandler('hello/foo/world/bar', 'GET')).to.be.eql(handlerWithParams);
+    expect(registry.getHandler('hello/foo/world/bar', 'GET'))
+      .to.be.eql(handlerWithParams);
   });
 
-  it('match handler with normal path', function() {
+  it('match handler with normal path', function () {
     expect(Registry._matchHandler('foo/bar', 'foo/bar')).to.eql(true);
   });
 
-  it('match handler with parameterized path', function() {
-    expect(Registry._matchHandler('download/:platform/:version', 'download/osx/1.0.0')).to.eql(true);
+  it('match handler with parameterized path', function () {
+    expect(Registry._matchHandler('download/:platform/:version',
+      'download/osx/1.0.0')).to.eql(true);
   });
 
-  it('match handler with parameterized path - false', function() {
-    expect(Registry._matchHandler('download/:platform/:version', 'sthelse/osx/1.0.0')).to.eql(false);
+  it('match handler with parameterized path - false', function () {
+    expect(Registry._matchHandler('download/:platform/:version',
+      'sthelse/osx/1.0.0')).to.eql(false);
   });
 
-  it('match handler with calacala parameterized path', function() {
-    expect(Registry._matchHandler('hello/:foo/world/:bar', 'hello/1/world/2')).to.eql(true);
+  it('match handler with calacala parameterized path', function () {
+    expect(Registry._matchHandler('hello/:foo/world/:bar', 'hello/1/world/2'))
+      .to.eql(true);
   });
 
   it('add static asset collect func', function () {

--- a/packages/skygear-core/test/cloud/registry.js
+++ b/packages/skygear-core/test/cloud/registry.js
@@ -132,6 +132,20 @@ describe('Registry', function () {
     expect(registry.getHandler('download/osx/1.0.0', 'GET')).to.be.eql(handlerWithParams);
   });
 
+  it('parse parameters in url', function() {
+    const registry = new Registry();
+    function handlerWithParams() {}
+    registry.registerHandler('download/:platform/:version', handlerWithParams, {
+      method: ['GET'],
+      authRequired: false,
+      userRequired: true
+    });
+    expect(registry.parseParamsInUrl('download/osx/1.0.0')).to.be.deep.eql({
+      platform: 'osx',
+      version: '1.0.0'
+    });
+  });
+
   it('add static asset collect func', function () {
     const registry = new Registry();
     function staticAsset() {}

--- a/packages/skygear-core/test/cloud/registry.js
+++ b/packages/skygear-core/test/cloud/registry.js
@@ -149,6 +149,22 @@ describe('Registry', function () {
     expect(registry.getHandler('hello/foo/world/bar', 'GET')).to.be.eql(handlerWithParams);
   });
 
+  it('match handler with normal path', function() {
+    expect(Registry._matchHandler('foo/bar', 'foo/bar')).to.eql(true);
+  });
+
+  it('match handler with parameterized path', function() {
+    expect(Registry._matchHandler('download/:platform/:version', 'download/osx/1.0.0')).to.eql(true);
+  });
+
+  it('match handler with parameterized path - false', function() {
+    expect(Registry._matchHandler('download/:platform/:version', 'sthelse/osx/1.0.0')).to.eql(false);
+  });
+
+  it('match handler with calacala parameterized path', function() {
+    expect(Registry._matchHandler('hello/:foo/world/:bar', 'hello/1/world/2')).to.eql(true);
+  });
+
   it('add static asset collect func', function () {
     const registry = new Registry();
     function staticAsset() {}

--- a/packages/skygear-core/test/cloud/registry.js
+++ b/packages/skygear-core/test/cloud/registry.js
@@ -149,7 +149,7 @@ describe('Registry', function () {
     expect(registry.getHandler('hello/foo/world/bar', 'GET')).to.be.eql(handlerWithParams);
   });
 
-  it('parse parameters in url', function() {
+  it('parse parameters in path', function() {
     const registry = new Registry();
     function handlerWithParams() {}
     registry.registerHandler('download/:platform/:version', handlerWithParams, {
@@ -157,13 +157,13 @@ describe('Registry', function () {
       authRequired: false,
       userRequired: true
     });
-    expect(registry.parseParamsInUrl('download/osx/1.0.0')).to.be.deep.eql({
+    expect(registry.parseParamsInPath('download/osx/1.0.0')).to.be.deep.eql({
       platform: 'osx',
       version: '1.0.0'
     });
   });
 
-  it('parse parameters in url, calacala parameters', function() {
+  it('parse parameters in path, calacala parameters', function() {
     const registry = new Registry();
     function handlerWithParams() {}
     registry.registerHandler('hello/:param1/world/:param2', handlerWithParams, {
@@ -171,13 +171,13 @@ describe('Registry', function () {
       authRequired: false,
       userRequired: true
     });
-    expect(registry.parseParamsInUrl('hello/foo/world/bar')).to.be.deep.eql({
+    expect(registry.parseParamsInPath('hello/foo/world/bar')).to.be.deep.eql({
       param1: 'foo',
       param2: 'bar'
     });
   });
 
-  it('parse parameters in non parameterized url', function() {
+  it('parse parameters in non parameterized path', function() {
     const registry = new Registry();
     function handlerWithParams() {}
     registry.registerHandler('a/normal/url', handlerWithParams, {
@@ -185,7 +185,7 @@ describe('Registry', function () {
       authRequired: false,
       userRequired: true
     });
-    expect(registry.parseParamsInUrl('a/normal/url')).to.be.deep.eql({});
+    expect(registry.parseParamsInPath('a/normal/url')).to.be.deep.eql({});
   });
 
   it('add static asset collect func', function () {

--- a/packages/skygear-core/test/cloud/transport/common.js
+++ b/packages/skygear-core/test/cloud/transport/common.js
@@ -19,7 +19,7 @@ import sinon from 'sinon';
 import {Registry} from '../../../lib/cloud/registry';
 import CommonTransport
   from '../../../lib/cloud/transport/common';
-import { SkygearResponse }
+import { SkygearResponse, SkygearRequest }
   from '../../../lib/cloud/transport/common';
 
 describe('CommonTransport', function () {
@@ -196,6 +196,7 @@ describe('CommonTransport', function () {
     const handlerFunc = sinon.spy(function (req) {
       return req.json.data;
     });
+    handlerFunc.handlerName = 'handler1';
     registry.getHandler = sinon.stub().returns(handlerFunc);
     const transport = new CommonTransport(registry);
     return transport.handlerHandler({
@@ -226,6 +227,24 @@ describe('CommonTransport', function () {
       );
       done();
     }).catch(done);
+  });
+
+  it('parse parameters in path', function() {
+    expect(SkygearRequest._parseParamsInPath('download/:platform/:version', '/download/osx/1.0.0')).to.be.deep.eql({
+      platform: 'osx',
+      version: '1.0.0'
+    });
+  });
+
+  it('parse parameters in path, calacala parameters', function() {
+    expect(SkygearRequest._parseParamsInPath('hello/:param1/world/:param2', '/hello/foo/world/bar')).to.be.deep.eql({
+      param1: 'foo',
+      param2: 'bar'
+    });
+  });
+
+  it('parse parameters in non parameterized path', function() {
+    expect(SkygearRequest._parseParamsInPath('a/normal/url', '/a/normal/url')).to.be.deep.eql({});
   });
 
   it('call with handlerHandler with params in req', function () {

--- a/packages/skygear-core/test/cloud/transport/common.js
+++ b/packages/skygear-core/test/cloud/transport/common.js
@@ -229,27 +229,30 @@ describe('CommonTransport', function () {
     }).catch(done);
   });
 
-  it('parse parameters in path', function() {
-    expect(SkygearRequest._parseParamsInPath('download/:platform/:version', '/download/osx/1.0.0')).to.be.deep.eql({
-      platform: 'osx',
-      version: '1.0.0'
-    });
+  it('parse parameters in path', function () {
+    expect(SkygearRequest._parseParamsInPath('download/:platform/:version',
+      '/download/osx/1.0.0')).to.be.deep.eql({
+        platform: 'osx',
+        version: '1.0.0'
+      });
   });
 
-  it('parse parameters in path, calacala parameters', function() {
-    expect(SkygearRequest._parseParamsInPath('hello/:param1/world/:param2', '/hello/foo/world/bar')).to.be.deep.eql({
-      param1: 'foo',
-      param2: 'bar'
-    });
+  it('parse parameters in path, calacala parameters', function () {
+    expect(SkygearRequest._parseParamsInPath('hello/:param1/world/:param2',
+      '/hello/foo/world/bar')).to.be.deep.eql({
+        param1: 'foo',
+        param2: 'bar'
+      });
   });
 
-  it('parse parameters in non parameterized path', function() {
-    expect(SkygearRequest._parseParamsInPath('a/normal/url', '/a/normal/url')).to.be.deep.eql({});
+  it('parse parameters in non parameterized path', function () {
+    expect(SkygearRequest._parseParamsInPath('a/normal/url',
+      '/a/normal/url')).to.be.deep.eql({});
   });
 
   it('call with handlerHandler with params in req', function () {
     const registry = new Registry();
-    registry.registerHandler('user/:id', function(req) {
+    registry.registerHandler('user/:id', function (req) {
       return req;
     }, {
       method: ['GET'],
@@ -279,7 +282,7 @@ describe('CommonTransport', function () {
       expect(body.params).to.deep.equal({
         id: '12345678'
       });
-    })
+    });
   });
 
   it('should call init event handler properly', function (done) {

--- a/packages/skygear-core/test/cloud/transport/common.js
+++ b/packages/skygear-core/test/cloud/transport/common.js
@@ -228,6 +228,41 @@ describe('CommonTransport', function () {
     }).catch(done);
   });
 
+  it('call with handlerHandler with params in req', function () {
+    const registry = new Registry();
+    registry.registerHandler('user/:id', function(req) {
+      return req;
+    }, {
+      method: ['GET'],
+      authRequired: false,
+      userRequired: true
+    });
+    const transport = new CommonTransport(registry);
+    return transport.handlerHandler({
+      kind: 'handler',
+      name: 'user/12345678',
+      param: {
+        method: 'GET',
+        header: {
+          'Content-Type': ['application/json'],
+          'Content-Length': ['16']
+        },
+        body: 'eyJkYXRhIjoi4pyTIn0=', // {"data":"✓"}
+        path: '/user/12345678',
+        query_string: 'q=1'
+      },
+      context: {
+        user_id: '0383f77599f1412e938f29ae79c3dcc8'
+      }
+    }).then((result) => {
+      const buf = Buffer.from(result.result.body, 'base64');
+      const body = JSON.parse(buf);
+      expect(body.params).to.deep.equal({
+        id: '12345678'
+      });
+    })
+  });
+
   it('should call init event handler properly', function (done) {
     const initInfo = {
       op: [],


### PR DESCRIPTION
**Add support to paths like this:**
`/downloads/:platform/:version`

**In skygear js cloud code:**
`skygearCloud.handler('downloads/:platform/:version', ......)`

**Request:**
`/downloads/osx/1.0.0`

**In the handler function:**
`req.params.platform === 'osx'`
`req.params.version === '1.0.0'`