### PR TITLE
Fix exception on server fails to bind address and return meaningful message

### DIFF
--- a/packages/skygear-core/lib/cloud/transport/http.js
+++ b/packages/skygear-core/lib/cloud/transport/http.js
@@ -41,8 +41,8 @@ class HTTPTransport extends CommonTransport {
     this.server.on('clientError', (err, socket) => {
       socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
     });
-    this.server.on('error', (err, socket) => {
-      socket.end('HTTP/1.1 500 Internal Server Error\r\n\r\n');
+    this.server.on('error', (err) => {
+      console.error(err);
     });
 
     const {


### PR DESCRIPTION
On server error, the callback only provide `err` and the socket is already
closed. We should only just log out the error for user to inspection.