### PR TITLE
Inject version string to skygear container with preprocess

### DIFF
--- a/gulp/context.js
+++ b/gulp/context.js
@@ -1,8 +1,14 @@
+var execSync = require('child_process').execSync;
+var version = execSync('git describe --always --tags --dirty') + "";
+version = version.trim();
+
 module.exports = {
   "dev": {
-    "API_URL": "http://skygear.dev/"
+    "API_URL": "http://skygear.dev/",
+    "SKYGEAR_VERSION": version
   },
   "production": {
-    "API_URL": "http://myapp.skygeario.com/"
+    "API_URL": "http://myapp.skygeario.com/",
+    "SKYGEAR_VERSION": version
   }
 }

--- a/packages/skygear-core/lib/container.js
+++ b/packages/skygear-core/lib/container.js
@@ -78,6 +78,24 @@ export class BaseContainer {
   }
 
   /**
+   * The version of Skygear.
+   *
+   * @type {String}
+   */
+  static get VERSION() {
+    return '/* @echo SKYGEAR_VERSION */';
+  }
+
+  /**
+   * The version of Skygear. Convenient getter.
+   *
+   * @type {String}
+   */
+  get VERSION() {
+    return this.constructor.VERSION;
+  }
+
+  /**
    * Sets a new end point and new API key to the container.
    *
    * @param {Object} options - configuration options of the skygear container

--- a/packages/skygear-core/test/container.js
+++ b/packages/skygear-core/test/container.js
@@ -22,6 +22,13 @@ import Role from '../lib/role';
 import mockSuperagent from './mock/superagent';
 
 describe('Container', function () {
+  it('should have version number injected to the container', function () {
+    let container = new Container();
+    expect(container.VERSION).to.eql(Container.VERSION);
+    expect(container.VERSION).to.exist();
+    expect(container.VERSION).to.not.be.empty();
+  });
+
   it('should have default end-point', function () {
     let container = new Container();
     container.pubsub.autoPubsub = false;


### PR DESCRIPTION
connect #278 

example:
```js
import skygear from 'skygear';
// or with window.skygear

console.log(skygear.VERSION);
```