### PR TITLE
Run lerna bootstrap in postinstall stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ endif
 .PHONY: vendor
 vendor:
 	$(DOCKER_RUN) npm install
-	$(DOCKER_RUN) npm run lerna bootstrap
 
 .PHONY: test
 test:

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "doc": "esdoc -c esdoc.json",
     "dev": "gulp --type dev dev",
     "minify": "gulp --type production minify",
+    "postinstall": "lerna bootstrap",
     "prepublish": "gulp --type production prepublish",
     "test": "gulp --type dev",
     "deploy": "gulp deploy --type production",


### PR DESCRIPTION
This fixes the problem when npm install runs the prepublish stage,
the dependencies used by skygear-core is not already installed.

connects #284