### PR TITLE
Use only annotated tags for version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell git describe --always --tags --dirty)
+VERSION := $(shell git describe --always)
 DOCS_AWS_BUCKET := docs.skygear.io
 DOCS_AWS_DISTRIBUTION := E31J8XF8IPV2V
 DOCS_PREFIX = /js/reference

--- a/scripts/docker-images/release/Makefile
+++ b/scripts/docker-images/release/Makefile
@@ -1,6 +1,6 @@
 GIT_SHA := $(shell git rev-parse HEAD)
 GIT_SHORT_SHA := $(shell git rev-parse --short HEAD)
-VERSION := $(shell git describe --always --tags)
+VERSION := $(shell git describe --always)
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 DOCKER_REGISTRY :=


### PR DESCRIPTION
This is because `latest` is also used as tag for release purposes and
`--tags` option makes `latest` appears in version string.