### PR TITLE
Fix `npm run dev` doesn’t rebuild

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -23,11 +23,7 @@ function bundle() {
       standalone: packageConfig.standalone
     });
     var bundler;
-    if (gutil.env.type != "dev") {
-      bundler = browserify(packageConfig.browserifySrc, bundlerArgs).ignore('react-native');
-    } else {
-      bundler = watchify(browserify(packageConfig.browserifySrc, bundlerArgs).ignore('react-native'));
-    }
+    bundler = browserify(packageConfig.browserifySrc, bundlerArgs).ignore('react-native');
 
     browserifyConfig.settings.transform.forEach(function(t) {
       bundler.transform(t);

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -46,7 +46,11 @@ gulp.task('babel', function () {
 });
 
 gulp.task('watch', ['browserify', 'babel'], function() {
-  gulp.watch(config.src, ['browserify', 'babel']);
+  var packageConfigs = config.getPackageConfigs();
+  var packagesSrc = packageConfigs.map(function(config) {
+    return config.src;
+  });
+  gulp.watch(packagesSrc, ['browserify', 'babel']);
 });
 
 gulp.task('prepublish', ['nsp', 'babel', 'browserify', 'minify']);


### PR DESCRIPTION
- Found `browserify` are called multiple times which is unexpected. Remove `watchify` from browserify, we are calling `browserify` in the watch tasks already.
- We were using `config.src` which is empty in watch task, updated getting the src from packageConfigs instead.