### PR TITLE
Update toJSON handling for array like object

### DIFF
--- a/packages/skygear-core/lib/util.js
+++ b/packages/skygear-core/lib/util.js
@@ -36,9 +36,13 @@ export function toJSON(v) {
   } else if (v.toJSON) {
     return v.toJSON();
   } else if (_.isObject(v)) {
+    // cannot use `map` directly
+    // because array-like object would give integer key instead of string key
+    // when calling map
     return _.chain(v)
-      .map((value, key) => {
-        return [key, toJSON(value)];
+      .keys()
+      .map((key) => {
+        return [key, toJSON(v[key])];
       })
       .fromPairs()
       .value();

--- a/packages/skygear-core/test/util.js
+++ b/packages/skygear-core/test/util.js
@@ -100,6 +100,17 @@ describe('util', function () {
     ]);
   });
 
+  it('toJSON array like object', function () {
+    const object = {
+      1: 'handsome',
+      length: 5
+    };
+    expect(toJSON(object)).to.eql({
+      1: 'handsome',
+      length: 5
+    });
+  });
+
   it('toJSON undefined', function () {
     expect(() => toJSON(undefined))
       .to.throw('toJSON does not support undefined value');


### PR DESCRIPTION
Mapping keys of the object instead of mapping the object directly.
The map implemention would give integer key for array-like object, while
skygear record does not need to recognize array-like object.

connect #321