### PR TITLE
Fix auth _getUser error handling

### DIFF
--- a/packages/skygear-core/lib/auth.js
+++ b/packages/skygear-core/lib/auth.js
@@ -384,7 +384,8 @@ export class AuthContainer {
     return this.container.store.getItem('skygear-user').then((userJSON) => {
       let attrs = JSON.parse(userJSON);
       this._user = new this._User(attrs);
-    }, (err) => {
+      return this._user;
+    }).catch((err) => {
       console.warn('Failed to get user', err);
       this._user = null;
       return null;


### PR DESCRIPTION
This has caused error in skygear.config if skygear-user is not a correct
user, making the pubsub connect not called.

connect #342 