### PR TITLE
Re-export SkygearError as skygear.Error

### DIFF
--- a/packages/skygear-core/lib/container.js
+++ b/packages/skygear-core/lib/container.js
@@ -28,7 +28,10 @@ import {Database} from './database';
 import Geolocation from './geolocation';
 import getStore from './store';
 import {Sequence} from './type';
-import {ErrorCodes} from './error';
+import {
+  SkygearError,
+  ErrorCodes
+} from './error';
 
 import {AuthContainer} from './auth';
 import {RelationContainer} from './relation';
@@ -300,6 +303,13 @@ export class BaseContainer {
    */
   get Following() {
     return this.relation.Following;
+  }
+
+  /**
+   * @type {SkygearError}
+   */
+  get Error() {
+    return SkygearError;
   }
 
   /**

--- a/packages/skygear-sso/lib/util.js
+++ b/packages/skygear-sso/lib/util.js
@@ -1,8 +1,7 @@
-import { SkygearError } from 'skygear-core/lib/error';
-
+import skygear from 'skygear-core';
 
 export function errorResponseFromMessage(message) {
   return {
-    error: new SkygearError(message)
+    error: new skygear.Error(message)
   };
 }


### PR DESCRIPTION
The lib user should not import from either `lib` nor `dist`. Since lib
user should not know the internal structure, we maintains the usage to
be `import skygear from 'skygear';` and use the SkygearError class as
Skygear.Error.