### PR TITLE
Don't set the X-Skygear-Access-Token on null

### DIFF
--- a/packages/skygear-core/lib/container.js
+++ b/packages/skygear-core/lib/container.js
@@ -514,8 +514,10 @@ export default class Container extends BaseContainer {
   _prepareRequestObject(action, data) {
     let requestObject = super._prepareRequestObject(action, data);
 
-    requestObject = requestObject
-      .set('X-Skygear-Access-Token', this.auth.accessToken);
+    if (this.auth.accessToken) {
+      requestObject = requestObject
+        .set('X-Skygear-Access-Token', this.auth.accessToken);
+    }
 
     if (this.timeoutOptions !== undefined && this.timeoutOptions !== null) {
       requestObject = requestObject.timeout(this.timeoutOptions);


### PR DESCRIPTION
Since HTTP header is sting, skygear-server will take `null` as the
access-token and resulting all request is invalid.