### PR TITLE
Fix cannot config skygear container for chat in react native

### DIFF
--- a/packages/skygear-core/lib/auth.js
+++ b/packages/skygear-core/lib/auth.js
@@ -35,7 +35,6 @@ export class AuthContainer {
 
     this._accessToken = null;
     this._user = null;
-    this._getAccessToken();
   }
 
   /**

--- a/packages/skygear-core/lib/cache.js
+++ b/packages/skygear-core/lib/cache.js
@@ -13,18 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import getStore from './store';
 
 /**
  * @private
  */
 export default class Cache {
 
-  constructor(prefix) {
+  constructor(prefix, store) {
     this._maxRetryCount = 1;
     this.prefix = prefix;
     this.map = {};
-    this.store = getStore();
+    this.store = store;
   }
 
   _applyNamespaceOnKey(key) {

--- a/packages/skygear-core/lib/container.js
+++ b/packages/skygear-core/lib/container.js
@@ -84,12 +84,6 @@ export class BaseContainer {
      * @private
      */
     this.ee = ee({});
-
-    /**
-     * Platform support default and react-native
-     * @private
-     */
-    this.platform = 'default';
   }
 
   /**
@@ -124,9 +118,6 @@ export class BaseContainer {
     }
     if (options.endPoint) {
       this.endPoint = options.endPoint;
-    }
-    if (options.platform) {
-      this.platform = options.platform;
     }
     return Promise.resolve(this);
   }
@@ -430,6 +421,11 @@ export default class Container extends BaseContainer {
 
   constructor() {
     super();
+    /**
+     * Platform support web and react-native
+     * @private
+     */
+    this.platform = 'web';
 
     this._auth = new AuthContainer(this);
     this._relation = new RelationContainer(this);
@@ -504,16 +500,12 @@ export default class Container extends BaseContainer {
    * @param {Object} options - configuration options of the skygear container
    * @param {String} options.apiKey - api key
    * @param {String} options.endPoint - end point
-   * @param {String} options.platform - default or react-native
+   * @param {String} options.platform - web or react-native
    * @return {Promise<Container>} promise with the skygear container
    */
   config(options) {
-    const changedPlatform = options.platform !== this.platform;
     return super.config(options).then(() => {
-      if (changedPlatform) {
-        return this.configPlatform();
-      }
-      return this;
+      return this._configPlatform(options.platform);
     }).then(() => {
       let promises = [
         this.auth._getUser(),
@@ -528,6 +520,7 @@ export default class Container extends BaseContainer {
       return this;
     });
   }
+
   /**
    * @private
    *
@@ -535,20 +528,24 @@ export default class Container extends BaseContainer {
    *
    * This will be called in config function when the platform option change.
    * Or you can call it after change the platform.
-   * Currently only react native is supported.
+   * Currently only react-native is supported.
    */
-  configPlatform() {
-    if (this.platform === 'react-native') {
-      // Those modules require react-native
-      // so we don't put them at the top level
-      const reactNativeStore = require('./react-native/store');
-      const { ReactNativePushContainer } = require('./react-native/push');
-      setStore(reactNativeStore);
-      this._store = reactNativeStore;
-      // Cache of DatabaseContainer will use the container store
-      // So we have to recreate the _db after the store is changed
-      this._db = new DatabaseContainer(this);
-      this._push = new ReactNativePushContainer(this);
+  _configPlatform(platform) {
+    if (platform && platform !== this.platform) {
+      this.platform = platform;
+
+      if (platform === 'react-native') {
+        // Those modules require react-native
+        // so we don't put them at the top level
+        const reactNativeStore = require('./react-native/store');
+        const { ReactNativePushContainer } = require('./react-native/push');
+        setStore(reactNativeStore);
+        this._store = reactNativeStore;
+        // Cache of DatabaseContainer will use the container store
+        // So we have to recreate the _db after the store is changed
+        this._db = new DatabaseContainer(this);
+        this._push = new ReactNativePushContainer(this);
+      }
     }
     return Promise.resolve(this);
   }

--- a/packages/skygear-core/lib/database.js
+++ b/packages/skygear-core/lib/database.js
@@ -44,7 +44,7 @@ export class Database {
      * @private
      */
     this.container = container;
-    this._cacheStore = new Cache(this.dbID);
+    this._cacheStore = new Cache(this.dbID, this.container.store);
     this._cacheResponse = true;
   }
 

--- a/packages/skygear-core/lib/push.js
+++ b/packages/skygear-core/lib/push.js
@@ -33,7 +33,6 @@ export class PushContainer {
     this.container = container;
 
     this._deviceID = null;
-    this._getDeviceID();
   }
 
   /**

--- a/packages/skygear-core/lib/react-native/index.js
+++ b/packages/skygear-core/lib/react-native/index.js
@@ -1,6 +1,5 @@
 import container from '../index';
 
-container.platform = 'react-native';
-container.configPlatform();
+container._configPlatform('react-native');
 
 export default container;

--- a/packages/skygear-core/lib/react-native/index.js
+++ b/packages/skygear-core/lib/react-native/index.js
@@ -1,18 +1,6 @@
-import Container from '../container';
-import {ReactNativePushContainer} from './push';
-import {setStore} from '../store';
-import reactNativeStore from './store';
+import container from '../index';
 
-class ReactNativeContainer extends Container {
+container.platform = 'react-native';
+container.configPlatform();
 
-  constructor() {
-    super();
-
-    this._push = new ReactNativePushContainer(this);
-  }
-
-}
-
-setStore(reactNativeStore);
-
-export default new ReactNativeContainer();
+export default container;

--- a/packages/skygear-core/test/cache.js
+++ b/packages/skygear-core/test/cache.js
@@ -16,6 +16,7 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import Cache from '../lib/cache';
+import getStore from '../lib/store';
 
 describe('Cache', function () {
 
@@ -23,7 +24,7 @@ describe('Cache', function () {
   let store;
 
   beforeEach(function () {
-    cache = new Cache('prefix');
+    cache = new Cache('prefix', getStore());
     store = {};
     cache.store = store;
   });


### PR DESCRIPTION
connect SkygearIO/chat-SDK-JS#78

- Removed `ReactNativeContainer` and reuse the same container for react-native
- Removed `_getAccessToken` and `_getDeviceID` in auth and push container constructor, since they will cause errors in react-native as the store is not ready before calling config. After this change, access token and device id will only be ready after calling config.

Both setups are supported
```
import skygear from 'skygear/react-native';
import skygearChat from 'skygear-chat';

skygear.config({...}).then(() => {
  skygearChat.createDirectConversation(...);
});
```

```
import skygear from 'skygear';
import skygearChat from 'skygear-chat';

skygear.config({
  ...,
  platform: 'react-native'
}).then(() => {
  skygearChat.createDirectConversation(...);  // I would get api key not configured error here
});
```