### PR TITLE
Fix register handler with different HTTP method

### DIFF
--- a/packages/skygear-core/lib/cloud/registry.js
+++ b/packages/skygear-core/lib/cloud/registry.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 /* eslint-disable no-var, camelcase */
+import _ from 'lodash';
+
 export class Registry {
   constructor() {
     this.funcMap = {
@@ -36,7 +38,32 @@ export class Registry {
     this.staticAsset = {};
   }
 
+  _addParamHandler(param) {
+    const kind = 'handler';
+    let list = this.paramMap[kind];
+    list = list.filter(function (item) {
+      if (
+        item.name === param.name &&
+        !_.isEmpty(_.intersection(item.methods, param.methods))
+      ) {
+        console.log(`Replacing previously registered ${kind}: ${item.name}`);
+        return false;
+      }
+      return true;
+    });
+    _.forEach(param.methods, function (method) {
+      const newParam = _.cloneDeep(param);
+      newParam.methods = [method];
+      list.push(newParam);
+    });
+    this.paramMap[kind] = list;
+  }
+
   _addParam(kind, param) {
+    if (kind === 'handler') {
+      return this._addParamHandler(param);
+    }
+
     let list = this.paramMap[kind];
     list = list.filter(function (item) {
       if (item.name === param.name) {

--- a/packages/skygear-core/test/cloud/registry.js
+++ b/packages/skygear-core/test/cloud/registry.js
@@ -115,6 +115,37 @@ describe('Registry', function () {
     expect(registry.getHandler('pubHandler', 'GET')).to.be.eql(pubHandler);
   });
 
+  it('add duplicate handler to funcList', function () {
+    const registry = new Registry();
+    function pubHandler() {}
+    registry.registerHandler('pubHandler', pubHandler, {
+      method: ['GET', 'POST'],
+      keyRequired: false,
+      userRequired: true
+    });
+    registry.registerHandler('pubHandler', pubHandler, {
+      method: ['POST'],
+      keyRequired: true,
+      userRequired: false
+    });
+    expect(registry.funcList().handler).to.be.eql([
+      {
+        name: 'pubHandler',
+        methods: ['GET'],
+        key_required: false,
+        user_required: true
+      },
+      {
+        name: 'pubHandler',
+        methods: ['POST'],
+        key_required: true,
+        user_required: false
+      }
+    ]);
+
+    expect(registry.getHandler('pubHandler', 'GET')).to.be.eql(pubHandler);
+  });
+
   it('add static asset collect func', function () {
     const registry = new Registry();
     function staticAsset() {}


### PR DESCRIPTION
This fixes the bug when registering multiple handler function
of the same path but with different HTTP method.

connects #325