### PR TITLE
Fix Record construct with falsy attrs

### DIFF
--- a/packages/skygear-core/lib/record.js
+++ b/packages/skygear-core/lib/record.js
@@ -78,10 +78,13 @@ const _metaKey = _.map(_metaAttrs, function (obj) {
  */
 export default class Record {
 
-  constructor(recordType, attrs = defaultAttrs) {
+  constructor(recordType, attrs) {
     if (!Record.validType(recordType)) {
       throw new Error(
         'RecordType is not valid. Please start with alphanumeric string.');
+    }
+    if (!attrs) {
+      attrs = _.assign({}, defaultAttrs);
     }
     this._recordType = recordType;
     // Favouring `id`, since `id` will always contains type information if

--- a/packages/skygear-core/test/record.js
+++ b/packages/skygear-core/test/record.js
@@ -34,6 +34,23 @@ describe('Record', function () {
     );
   });
 
+  it('handle falsy attrs', function () {
+    let r = new Record('user', null);
+    let tuple = r.id.split("/");
+    expect(v4Spec.test(tuple[1])).to.be.true();
+    expect(tuple[0]).to.equal('user');
+
+    r = new Record('user', undefined);
+    tuple = r.id.split("/");
+    expect(v4Spec.test(tuple[1])).to.be.true();
+    expect(tuple[0]).to.equal('user');
+
+    r = new Record('user', false);
+    tuple = r.id.split("/");
+    expect(v4Spec.test(tuple[1])).to.be.true();
+    expect(tuple[0]).to.equal('user');
+  });
+
   it('generate with uuid v4 as id', function () {
     let r = new Record('note');
     let tuple = r.id.split("/");


### PR DESCRIPTION
Fix #361 

When code compiled, the default attribute only check for `undefined` but not `null`.
```js
// original
class Record {
  constructor(recordType, attrs = defaultAttrs) {
  }
}
// compiled
function Record(recordType) {
    var attrs = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultAttrs;
}
```

According [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/default_parameters):  
Default function parameters allow formal parameters to be initialized with default values if **no value or undefined** is passed.

When auth init with no user, `null` is passed into Record constructor and triggered error.
https://github.com/SkygearIO/skygear-SDK-JS/blob/master/packages/skygear-core/lib/auth.js#L383
```js
return this.container.store.getItem('skygear-user').then((userJSON) => {
  let attrs = JSON.parse(userJSON); // attrs = null
  this._user = new this._User(attrs);
  return this._user;
})
```