### PR TITLE
Fix cannot upload asset if passing asset through record constructer

### DIFF
--- a/packages/skygear-core/lib/record.js
+++ b/packages/skygear-core/lib/record.js
@@ -219,7 +219,7 @@ export default class Record {
 
     _.each(attrs, (value, key) => {
       if (key.indexOf('_') !== 0) {
-        if (_.isObject(value)) {
+        if (_.isPlainObject(value)) {
           this[key] = fromJSON(value);
         } else {
           this[key] = value;

--- a/packages/skygear-core/test/record.js
+++ b/packages/skygear-core/test/record.js
@@ -19,6 +19,7 @@ import uuid from 'uuid';
 import Record, {isRecord} from '../lib/record';
 import Role from '../lib/role';
 import Reference from '../lib/reference';
+import Asset from '../lib/asset';
 import Geolocation from '../lib/geolocation';
 import {Sequence, UnknownValue} from '../lib/type';
 import {AccessLevel} from '../lib/acl';
@@ -92,6 +93,37 @@ describe('Record', function () {
     let r = new rCls();
     expect(isRecord(r)).to.be.true();
   });
+
+  it('constructor attrs with different type objects should be retained',
+    function () {
+      const picture = new Asset({
+        name: 'asset-name',
+        url: 'http://server-will-ignore.me/'
+      });
+      const location = new Geolocation(10, 20);
+      let r = new Record('note', {
+        _id: 'note/uid',
+        attachment: picture,
+        geo: location
+      });
+      expect(r['attachment']).to.be.an.instanceof(Asset);
+      expect(r['geo']).to.be.an.instanceof(Geolocation);
+      expect(r.toJSON()).eql({
+        _access: null,
+        _id: 'note/uid',
+        attachment: {
+          $type: 'asset',
+          $name: 'asset-name',
+          $url: 'http://server-will-ignore.me/'
+        },
+        geo: {
+          $type: 'geo',
+          $lat: 10,
+          $lng: 20
+        }
+      });
+    }
+  );
 });
 
 describe('Extended Record', function () {


### PR DESCRIPTION
connect #432 

In record constructer we check if the attribute value is object we will treat value as dictionary and parse its content. It accidentally change typed objects like asset or location to plain objects. This should only happen in plain object.