### PR TITLE
Check window closure more frequently

### DIFF
--- a/packages/skygear-sso/lib/observer.js
+++ b/packages/skygear-sso/lib/observer.js
@@ -14,7 +14,7 @@ export class NewWindowObserver {
         if (this.newWindow.closed) {
           reject(errorResponseFromMessage('User cancel the login flow'));
         }
-      }, 3000);
+      }, 1000);
     });
   }
 


### PR DESCRIPTION
This should fix the test case where the test timed out waiting for the
window to close.