### PR TITLE
Export getSigner

### DIFF
--- a/packages/skygear-core/lib/cloud/index.js
+++ b/packages/skygear-core/lib/cloud/index.js
@@ -443,3 +443,4 @@ export { getContainer, publishEventsToChannels } from './container';
 export const ErrorCodes = _ErrorCodes;
 export const SkygearError = _SkygearError;
 export const log = _createLogger;
+export { getSigner } from './asset';


### PR DESCRIPTION
Currently we have to write 

```
import { getSigner } from "skygear-core/dist/cloud/asset";
```

to use signer.

it is much better to write

```
import { getSigner } from "skygear/cloud";
```

because importing from `dist` assumes the underlying file structure which may change at any time.