### PR TITLE
Web authorize with oidc flow

### DIFF
--- a/packages/example/index.js
+++ b/packages/example/index.js
@@ -9,6 +9,7 @@ const APP_ENDPOINT = process.env.SKYGEAR_APP_ENDPOINT || "http://localhost:3000"
 const AUTH_ENDPOINT = process.env.SKYGEAR_AUTH_ENDPOINT || "";
 const ASSET_ENDPOINT = process.env.SKYGEAR_ASSET_ENDPOINT || "";
 const CLIENT_ID = process.env.SKYGEAR_CLIENT_ID || "api_key";
+const IS_THIRD_PARTY_APP = process.env.SKYGEAR_IS_THIRD_PARTY_APP === 'true';
 const PORT = parseInt(process.env.PORT || "9999", 10);
 
 const dist = path.join(__dirname, "./dist");
@@ -22,7 +23,8 @@ function compileFile(basename) {
     .replace(/__SKYGEAR_APP_ENDPOINT__/g, APP_ENDPOINT)
     .replace(/__SKYGEAR_AUTH_ENDPOINT__/g, AUTH_ENDPOINT)
     .replace(/__SKYGEAR_ASSET_ENDPOINT__/g, ASSET_ENDPOINT)
-    .replace(/__SKYGEAR_CLIENT_ID__/g, CLIENT_ID);
+    .replace(/__SKYGEAR_CLIENT_ID__/g, CLIENT_ID)
+    .replace(/__SKYGEAR_IS_THIRD_PARTY_APP__/g, IS_THIRD_PARTY_APP);
   fs.writeFileSync(distPath, content);
 }
 

--- a/packages/example/src/authui.html
+++ b/packages/example/src/authui.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+  <script src="/skygear-web.iife.js"></script>
+  <script src="/helper.js"></script>
+  <title>Auth UI</title>
+</head>
+<body>
+  <div class="container">
+    <a href="/">
+      <h2>Back to Index</h2>
+    </a>
+  </div>
+  <form class="container" onsubmit="onSubmitAuthorize(event)">
+    <div class="form-group">
+      <h1>Authorize</h1>
+    </div>
+    <div class="form-group">
+      <button type="submit" class="btn btn-primary">Authorize</button>
+    </div>
+    <div class="form-group">
+      <label>Synopsis</label>
+      <textarea id="authorizeSynopsis" class="form-control" readonly=""></textarea>
+    </div>
+    <div class="form-group">
+      <label>Result</label>
+      <textarea id="authorizeResult" class="form-control" readonly=""></textarea>
+    </div>
+  </form>
+  <form class="container" onsubmit="onSubmitExchangeToken(event)">
+    <div class="form-group">
+      <h1>ExchangeToken</h1>
+    </div>
+    <div class="form-group">
+      <button type="submit" class="btn btn-primary">Exchange Token</button>
+    </div>
+    <div class="form-group">
+      <label>Synopsis</label>
+      <textarea id="exchangeTokenSynopsis" class="form-control" readonly=""></textarea>
+    </div>
+    <div class="form-group">
+      <label>Result</label>
+      <textarea id="exchangeTokenResult" class="form-control" readonly=""></textarea>
+    </div>
+  </form>
+  <script>
+
+function getRedirectURI() {
+  var redirectURI = window.location.href;
+  var idx = redirectURI.indexOf("?");
+  if (idx !== -1 ){
+    // remove query part if needed
+    redirectURI = redirectURI.slice(0, idx);
+  }
+  return redirectURI;
+}
+
+function setupAuthorizeSynopsis() {
+  var synopsisTextArea = document.getElementById("authorizeSynopsis");
+  var funcExpr = "skygear.auth.authorize";
+  var redirectURI = getRedirectURI();
+  var s = stringifyFunctionCall(funcExpr, {
+    redirectURI: redirectURI,
+  });
+  synopsisTextArea.value = s;
+}
+
+function onSubmitAuthorize(e) {
+  e.preventDefault();
+  e.stopPropagation();
+
+  var resultTextArea = document.getElementById("authorizeResult");
+  var redirectURI = getRedirectURI();
+  skygear.auth.authorize({
+    redirectURI: redirectURI
+  }).then(function() {
+    resultTextArea.value = "OK";
+  }, function(e) {
+    resultTextArea.value = JSON.stringify(e);
+  });
+}
+
+
+function setupExchangeTokenSynopsis() {
+  var synopsisTextArea = document.getElementById("exchangeTokenSynopsis");
+  var funcExpr = "skygear.auth.exchangeToken";
+  var s = stringifyFunctionCall(funcExpr);
+  synopsisTextArea.value = s;
+}
+
+function onSubmitExchangeToken(e) {
+  e.preventDefault();
+  e.stopPropagation();
+
+  var resultTextArea = document.getElementById("exchangeTokenResult");
+
+  skygear.auth.exchangeToken().then(function(result) {
+    resultTextArea.value = JSON.stringify(result);
+  }, function(e) {
+    console.log(e);
+    resultTextArea.value = JSON.stringify(e);
+  });
+}
+
+skygear.configure({
+  appEndpoint: "__SKYGEAR_APP_ENDPOINT__",
+  authEndpoint: "__SKYGEAR_AUTH_ENDPOINT__",
+  assetEndpoint: "__SKYGEAR_ASSET_ENDPOINT__",
+  clientID: "__SKYGEAR_CLIENT_ID__",
+  isThirdPartyApp: __SKYGEAR_IS_THIRD_PARTY_APP__,
+}).then(function() {
+  setupAuthorizeSynopsis();
+  setupExchangeTokenSynopsis();
+}, function(e) {
+  console.error(e);
+});
+  </script>
+</body>
+</html>

--- a/packages/example/src/authui.html
+++ b/packages/example/src/authui.html
@@ -14,36 +14,36 @@
       <h2>Back to Index</h2>
     </a>
   </div>
-  <form class="container" onsubmit="onSubmitAuthorize(event)">
+  <form class="container" onsubmit="onSubmitStartAuthorization(event)">
     <div class="form-group">
-      <h1>Authorize</h1>
+      <h1>Start Authorization</h1>
     </div>
     <div class="form-group">
-      <button type="submit" class="btn btn-primary">Authorize</button>
+      <button type="submit" class="btn btn-primary">Start Authorization</button>
     </div>
     <div class="form-group">
       <label>Synopsis</label>
-      <textarea id="authorizeSynopsis" class="form-control" readonly=""></textarea>
+      <textarea id="startAuthorizationSynopsis" class="form-control" readonly=""></textarea>
     </div>
     <div class="form-group">
       <label>Result</label>
-      <textarea id="authorizeResult" class="form-control" readonly=""></textarea>
+      <textarea id="startAuthorizationResult" class="form-control" readonly=""></textarea>
     </div>
   </form>
-  <form class="container" onsubmit="onSubmitExchangeToken(event)">
+  <form class="container" onsubmit="onSubmitFinishAuthorization(event)">
     <div class="form-group">
-      <h1>ExchangeToken</h1>
+      <h1>Finish Authorization</h1>
     </div>
     <div class="form-group">
-      <button type="submit" class="btn btn-primary">Exchange Token</button>
+      <button type="submit" class="btn btn-primary">Finish Authorization</button>
     </div>
     <div class="form-group">
       <label>Synopsis</label>
-      <textarea id="exchangeTokenSynopsis" class="form-control" readonly=""></textarea>
+      <textarea id="finishAuthorizationSynopsis" class="form-control" readonly=""></textarea>
     </div>
     <div class="form-group">
       <label>Result</label>
-      <textarea id="exchangeTokenResult" class="form-control" readonly=""></textarea>
+      <textarea id="finishAuthorizationResult" class="form-control" readonly=""></textarea>
     </div>
   </form>
   <script>
@@ -58,9 +58,9 @@ function getRedirectURI() {
   return redirectURI;
 }
 
-function setupAuthorizeSynopsis() {
-  var synopsisTextArea = document.getElementById("authorizeSynopsis");
-  var funcExpr = "skygear.auth.authorize";
+function setupStartAuthorizationSynopsis() {
+  var synopsisTextArea = document.getElementById("startAuthorizationSynopsis");
+  var funcExpr = "skygear.auth.startAuthorization";
   var redirectURI = getRedirectURI();
   var s = stringifyFunctionCall(funcExpr, {
     redirectURI: redirectURI,
@@ -68,13 +68,13 @@ function setupAuthorizeSynopsis() {
   synopsisTextArea.value = s;
 }
 
-function onSubmitAuthorize(e) {
+function onSubmitStartAuthorization(e) {
   e.preventDefault();
   e.stopPropagation();
 
-  var resultTextArea = document.getElementById("authorizeResult");
+  var resultTextArea = document.getElementById("startAuthorizationResult");
   var redirectURI = getRedirectURI();
-  skygear.auth.authorize({
+  skygear.auth.startAuthorization({
     redirectURI: redirectURI
   }).then(function() {
     resultTextArea.value = "OK";
@@ -84,20 +84,20 @@ function onSubmitAuthorize(e) {
 }
 
 
-function setupExchangeTokenSynopsis() {
-  var synopsisTextArea = document.getElementById("exchangeTokenSynopsis");
-  var funcExpr = "skygear.auth.exchangeToken";
+function setupFinishAuthorizationSynopsis() {
+  var synopsisTextArea = document.getElementById("finishAuthorizationSynopsis");
+  var funcExpr = "skygear.auth.finishAuthorization";
   var s = stringifyFunctionCall(funcExpr);
   synopsisTextArea.value = s;
 }
 
-function onSubmitExchangeToken(e) {
+function onSubmitFinishAuthorization(e) {
   e.preventDefault();
   e.stopPropagation();
 
-  var resultTextArea = document.getElementById("exchangeTokenResult");
+  var resultTextArea = document.getElementById("finishAuthorizationResult");
 
-  skygear.auth.exchangeToken().then(function(result) {
+  skygear.auth.finishAuthorization().then(function(result) {
     resultTextArea.value = JSON.stringify(result);
   }, function(e) {
     console.log(e);
@@ -112,8 +112,8 @@ skygear.configure({
   clientID: "__SKYGEAR_CLIENT_ID__",
   isThirdPartyApp: __SKYGEAR_IS_THIRD_PARTY_APP__,
 }).then(function() {
-  setupAuthorizeSynopsis();
-  setupExchangeTokenSynopsis();
+  setupStartAuthorizationSynopsis();
+  setupFinishAuthorizationSynopsis();
 }, function(e) {
   console.error(e);
 });

--- a/packages/example/src/index.html
+++ b/packages/example/src/index.html
@@ -20,6 +20,7 @@
       <li class="list-group-item"><a href="/verification.html">User Verification</a></li>
       <li class="list-group-item"><a href="/forgotpassword.html">Forgot Password</a></li>
       <li class="list-group-item"><a href="/sso.html">Single sign-on (SSO)</a></li>
+      <li class="list-group-item"><a href="/authui.html">Auth UI</a></li>
     </ul>
   </div>
   <div class="container">

--- a/packages/skygear-core/src/client.ts
+++ b/packages/skygear-core/src/client.ts
@@ -966,6 +966,8 @@ export abstract class BaseAPIClient {
     const userinfo = await this._fetchOIDCRequest(config.userinfo_endpoint, {
       method: "GET",
       headers: headers,
+      mode: "cors",
+      credentials: "include",
     });
     const result = _decodeAuthResponseFromOIDCUserinfo(userinfo);
     return result;

--- a/packages/skygear-core/src/client.ts
+++ b/packages/skygear-core/src/client.ts
@@ -22,7 +22,6 @@ import {
   _OIDCTokenResponse,
   _OIDCTokenRequest,
   OAuthError,
-  User,
 } from "./types";
 import { decodeError, SkygearError } from "./error";
 import { encodeQuery } from "./url";
@@ -31,7 +30,7 @@ import {
   decodeSession,
   decodeAuthenticator,
   decodeIdentity,
-  _decodeUserFromOIDCUserinfo,
+  _decodeAuthResponseFromOIDCUserinfo,
 } from "./encoding";
 import { _encodeBase64FromString } from "./base64";
 
@@ -958,17 +957,17 @@ export abstract class BaseAPIClient {
   /**
    * @internal
    */
-  async _oidcUserInfoRequest(
-    accessTokenType: string,
-    accessToken: string
-  ): Promise<User> {
+  async _oidcUserInfoRequest(accessToken?: string): Promise<AuthResponse> {
+    const headers: { [name: string]: string } = {};
+    if (accessToken) {
+      headers["authorization"] = `bearer ${accessToken}`;
+    }
     const config = await this._fetchOIDCConfiguration();
     const userinfo = await this._fetchOIDCRequest(config.userinfo_endpoint, {
       method: "GET",
-      headers: {
-        authorization: `${accessTokenType} ${accessToken}`,
-      },
+      headers: headers,
     });
-    return _decodeUserFromOIDCUserinfo(userinfo);
+    const result = _decodeAuthResponseFromOIDCUserinfo(userinfo);
+    return result;
   }
 }

--- a/packages/skygear-core/src/encoding.ts
+++ b/packages/skygear-core/src/encoding.ts
@@ -261,3 +261,26 @@ export function _encodeExtraSessionInfoOptions(
     device_name: o.deviceName,
   };
 }
+
+/**
+ * @internal
+ */
+export function _decodeUserFromOIDCUserinfo(u: any): User {
+  // TODO: confirm userinfo return attributes
+  const id = u.sub;
+  const createdAt = new Date(u.created_at || 0);
+  const lastLoginAt = new Date(u.last_login_at || 0);
+  const isVerified = u.is_verified;
+  const isManuallyVerified = u.is_manually_verified;
+  const isDisabled = u.is_disabled;
+  const metadata = u.metadata;
+  return {
+    id,
+    createdAt,
+    lastLoginAt,
+    isManuallyVerified,
+    isVerified,
+    isDisabled,
+    metadata,
+  };
+}

--- a/packages/skygear-core/src/encoding.ts
+++ b/packages/skygear-core/src/encoding.ts
@@ -20,6 +20,7 @@ export function decodeAuthResponse(r: any): AuthResponse {
     refresh_token,
     session_id,
     mfa_bearer_token,
+    expires_in,
   } = r;
   const response: AuthResponse = {
     user: decodeUser(user),
@@ -38,6 +39,9 @@ export function decodeAuthResponse(r: any): AuthResponse {
   }
   if (mfa_bearer_token) {
     response.mfaBearerToken = mfa_bearer_token;
+  }
+  if (expires_in) {
+    response.expiresIn = expires_in;
   }
   return response;
 }

--- a/packages/skygear-core/src/encoding.ts
+++ b/packages/skygear-core/src/encoding.ts
@@ -265,22 +265,27 @@ export function _encodeExtraSessionInfoOptions(
 /**
  * @internal
  */
-export function _decodeUserFromOIDCUserinfo(u: any): User {
-  // TODO: confirm userinfo return attributes
-  const id = u.sub;
-  const createdAt = new Date(u.created_at || 0);
-  const lastLoginAt = new Date(u.last_login_at || 0);
-  const isVerified = u.is_verified;
-  const isManuallyVerified = u.is_manually_verified;
-  const isDisabled = u.is_disabled;
-  const metadata = u.metadata;
-  return {
-    id,
-    createdAt,
-    lastLoginAt,
-    isManuallyVerified,
-    isVerified,
-    isDisabled,
-    metadata,
+export function _decodeAuthResponseFromOIDCUserinfo(u: any): AuthResponse {
+  const { sub, skygear_user, skygear_identity, skygear_session_id } = u;
+
+  if (!skygear_user) {
+    throw new Error("missing skygear_user in userinfo");
+  }
+
+  const user = decodeUser(skygear_user);
+  user.id = sub;
+
+  const response: AuthResponse = {
+    user: user,
   };
+
+  if (skygear_session_id) {
+    response.sessionID = skygear_session_id;
+  }
+
+  if (skygear_identity) {
+    response.identity = decodeIdentity(skygear_identity);
+  }
+
+  return response;
 }

--- a/packages/skygear-core/src/storage.ts
+++ b/packages/skygear-core/src/storage.ts
@@ -61,6 +61,10 @@ function keyMFABearerToken(name: string): string {
   return `${name}_mfaBearerToken`;
 }
 
+function keyOIDCCodeVerifier(name: string): string {
+  return `${name}_oidcCodeVerifier`;
+}
+
 /**
  * @internal
  */
@@ -186,6 +190,10 @@ export class GlobalJSONContainerStorage implements ContainerStorage {
     await this.storage.safeSet(keyMFABearerToken(namespace), mfaBearerToken);
   }
 
+  async setOIDCCodeVerifier(namespace: string, code: string) {
+    await this.storage.safeSet(keyOIDCCodeVerifier(namespace), code);
+  }
+
   async getUser(namespace: string): Promise<User | null> {
     const userJSON = await this.storage.safeGetJSON(keyUser(namespace));
     if (userJSON) {
@@ -250,6 +258,10 @@ export class GlobalJSONContainerStorage implements ContainerStorage {
     return this.storage.safeGet(keyMFABearerToken(namespace));
   }
 
+  async getOIDCCodeVerifier(namespace: string): Promise<string | null> {
+    return this.storage.safeGet(keyOIDCCodeVerifier(namespace));
+  }
+
   async delUser(namespace: string) {
     await this.storage.safeDel(keyUser(namespace));
   }
@@ -284,5 +296,9 @@ export class GlobalJSONContainerStorage implements ContainerStorage {
 
   async delMFABearerToken(namespace: string) {
     await this.storage.safeDel(keyMFABearerToken(namespace));
+  }
+
+  async delOIDCCodeVerifier(namespace: string) {
+    await this.storage.safeDel(keyOIDCCodeVerifier(namespace));
   }
 }

--- a/packages/skygear-core/src/types.ts
+++ b/packages/skygear-core/src/types.ts
@@ -241,6 +241,7 @@ export interface AuthResponse {
   refreshToken?: string;
   sessionID?: string;
   mfaBearerToken?: string;
+  expires_in?: number;
 }
 
 /**
@@ -707,11 +708,12 @@ export interface _OIDCConfiguration {
  * @internal
  */
 export interface _OIDCTokenRequest {
-  grant_type: string;
-  code: string;
-  redirect_uri: string;
+  grant_type: "authorization_code" | "refresh_token";
   client_id: string;
-  code_verifier: string;
+  redirect_uri?: string;
+  code?: string;
+  code_verifier?: string;
+  refresh_token?: string;
 }
 
 /**

--- a/packages/skygear-core/src/types.ts
+++ b/packages/skygear-core/src/types.ts
@@ -241,7 +241,7 @@ export interface AuthResponse {
   refreshToken?: string;
   sessionID?: string;
   mfaBearerToken?: string;
-  expires_in?: number;
+  expiresIn?: number;
 }
 
 /**

--- a/packages/skygear-core/src/types.ts
+++ b/packages/skygear-core/src/types.ts
@@ -672,6 +672,19 @@ export interface AuthenticationSession {
 }
 
 /**
+ * OAuthError represents the oauth error response.
+ * https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+ *
+ * @public
+ */
+export interface OAuthError {
+  state?: string;
+  error: string;
+  error_description?: string;
+  error_uri?: string;
+}
+
+/**
  * @internal
  */
 export interface _OIDCConfiguration {
@@ -688,6 +701,28 @@ export interface _OIDCConfiguration {
   claims_supported: string;
   code_challenge_methods_supported: string;
   revocation_endpoint: string;
+}
+
+/**
+ * @internal
+ */
+export interface _OIDCTokenRequest {
+  grant_type: string;
+  code: string;
+  redirect_uri: string;
+  client_id: string;
+  code_verifier: string;
+}
+
+/**
+ * @internal
+ */
+export interface _OIDCTokenResponse {
+  id_token: string;
+  token_type: string;
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
 }
 
 /**

--- a/packages/skygear-core/src/types.ts
+++ b/packages/skygear-core/src/types.ts
@@ -266,6 +266,7 @@ export interface ContainerStorage {
     authenticationSession: AuthenticationSession
   ): Promise<void>;
   setMFABearerToken(namespace: string, mfaBearerToken: string): Promise<void>;
+  setOIDCCodeVerifier(namespace: string, code: string): Promise<void>;
 
   getUser(namespace: string): Promise<User | null>;
   getIdentity(namespace: string): Promise<Identity | null>;
@@ -281,6 +282,7 @@ export interface ContainerStorage {
     namespace: string
   ): Promise<AuthenticationSession | null>;
   getMFABearerToken(namespace: string): Promise<string | null>;
+  getOIDCCodeVerifier(namespace: string): Promise<string | null>;
 
   delUser(namespace: string): Promise<void>;
   delIdentity(namespace: string): Promise<void>;
@@ -291,6 +293,7 @@ export interface ContainerStorage {
   delOAuthCodeVerifier(namespace: string): Promise<void>;
   delAuthenticationSession(namespace: string): Promise<void>;
   delMFABearerToken(namespace: string): Promise<void>;
+  delOIDCCodeVerifier(namespace: string): Promise<void>;
 }
 
 /**
@@ -666,6 +669,25 @@ export interface AuthenticationSession {
    * Current step in authentication session.
    */
   step: "identity" | "mfa";
+}
+
+/**
+ * @internal
+ */
+export interface _OIDCConfiguration {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  jwks_uri: string;
+  scopes_supported: string;
+  response_types_supported: string;
+  grant_types_supported: string;
+  subject_types_supported: string;
+  id_token_signing_alg_values_supported: string;
+  claims_supported: string;
+  code_challenge_methods_supported: string;
+  revocation_endpoint: string;
 }
 
 /**

--- a/packages/skygear-core/src/url.test.ts
+++ b/packages/skygear-core/src/url.test.ts
@@ -1,4 +1,9 @@
-import { encodeQueryComponent, encodeQuery } from "./url";
+import {
+  encodeQueryComponent,
+  encodeQuery,
+  decodeQueryComponent,
+  decodeQuery,
+} from "./url";
 
 describe("encodeQueryComponent", () => {
   const f = encodeQueryComponent;
@@ -45,5 +50,28 @@ describe("encodeQuery", () => {
 
   it("support empty key", () => {
     expect(f([["", "a"], ["", "b"]])).toEqual("?=a&=b");
+  });
+});
+
+describe("decodeQueryComponent", () => {
+  const f = decodeQueryComponent;
+
+  it("decode space", () => {
+    expect(f("a+b%20c")).toEqual("a b c");
+  });
+});
+
+describe("decodeQuery", () => {
+  const f = decodeQuery;
+
+  it("support key and value", () => {
+    expect(f("a=aValue&b=bValue")).toEqual([["a", "aValue"], ["b", "bValue"]]);
+  });
+
+  it("support decode value", () => {
+    expect(f("key1=a+b%20c&key2=d")).toEqual([
+      ["key1", "a b c"],
+      ["key2", "d"],
+    ]);
   });
 });

--- a/packages/skygear-core/src/url.ts
+++ b/packages/skygear-core/src/url.ts
@@ -32,3 +32,36 @@ export function encodeQuery(query?: [string, string][]): string {
   }
   return output;
 }
+
+/**
+ * @public
+ */
+export function decodeQueryComponent(s: string): string {
+  return decodeURIComponent(s.replace(/\+/g, "%20"));
+}
+
+/**
+ * @public
+ */
+export function decodeQuery(query?: string): [string, string][] {
+  if (!query) {
+    return [];
+  }
+  const vars = query.split("&");
+  const result: [string, string][] = [];
+  for (let i = 0; i < vars.length; i++) {
+    const idx = vars[i].indexOf("=");
+    let key = "";
+    let value = "";
+    if (idx === -1) {
+      key = vars[i];
+      value = "";
+    } else {
+      key = vars[i].slice(0, idx);
+      value = vars[i].slice(idx + 1);
+    }
+    result.push([decodeQueryComponent(key), decodeQueryComponent(value)]);
+  }
+
+  return result;
+}

--- a/packages/skygear-web/src/container.ts
+++ b/packages/skygear-web/src/container.ts
@@ -371,6 +371,17 @@ export class WebAuthContainer<T extends WebAPIClient> extends AuthContainer<T> {
     const authorizeEndpoint = await this._oidc.authorizeEndpoint(options);
     window.location.href = authorizeEndpoint;
   }
+
+  /**
+   * Exchange access token
+   *
+   * exchangeToken read window.location.
+   * It checks if error is present and rejects with OAuthError.
+   * Otherwise assume code is present, make a token request.
+   */
+  async exchangeToken(): Promise<{ user: User; state?: string }> {
+    return this._oidc.exchangeTokenFromCode(window.location.href);
+  }
 }
 
 /**

--- a/packages/skygear-web/src/container.ts
+++ b/packages/skygear-web/src/container.ts
@@ -363,24 +363,24 @@ export class WebAuthContainer<T extends WebAPIClient> extends AuthContainer<T> {
   }
 
   /**
-   * Open authorize page
+   * Start authorization by opening authorize page
    *
    * @param options - authorize options
    */
-  async authorize(options: AuthorizeOptions): Promise<void> {
+  async startAuthorization(options: AuthorizeOptions): Promise<void> {
     const authorizeEndpoint = await this._oidc.authorizeEndpoint(options);
     window.location.href = authorizeEndpoint;
   }
 
   /**
-   * Exchange access token
+   * Finish authorization
    *
    * exchangeToken read window.location.
    * It checks if error is present and rejects with OAuthError.
    * Otherwise assume code is present, make a token request.
    */
-  async exchangeToken(): Promise<{ user: User; state?: string }> {
-    return this._oidc.exchangeTokenFromCode(window.location.href);
+  async finishAuthorization(): Promise<{ user: User; state?: string }> {
+    return this._oidc.finishAuthorization(window.location.href);
   }
 }
 


### PR DESCRIPTION
require #557 
connect #554 

To try the example with other provider like `keycloak`, we can configure to provide keycloak endpoint in auth endpoint, e.g.:
```
SKYGEAR_APP_ENDPOINT=ANY_VALID_ENDPOINT \
SKYGEAR_AUTH_ENDPOINT=http://localhost:8080/auth/realms/master \
SKYGEAR_CLIENT_ID=CLIENT_ID \
# SKYGEAR_IS_THIRD_PARTY_APP=true \
npm run example
```

TODO:
- Update error handling, should have OAuthError should be an error object instead interface

TBD:
- ~~The current flow use response of userinfo endpoint to construct the user, we should decide what attributes will be return from the userinfo endpoint, or we should change some of the user object attributes optional~~
- ~~The new SDK use oidc token endpoint to renew token, we assume that user is using the new server with new sdk.~~
- But I am not sure how old sdk works with new server, if the new gateway behavior is always proxy the request and no longer have header `x-skygear-try-refresh-token`? Or we don't need to take care this? As the old app that we need to migrate is using cookie transport?

Remarks:
- old api auth response should update to return expires_in, otherwise sdk will not call refresh token
