### PR TITLE
Authui logout

### DIFF
--- a/packages/example/src/authui.html
+++ b/packages/example/src/authui.html
@@ -46,6 +46,22 @@
       <textarea id="finishAuthorizationResult" class="form-control" readonly=""></textarea>
     </div>
   </form>
+  <form class="container" onsubmit="onSubmitLogout(event)">
+    <div class="form-group">
+      <h1>Logout</h1>
+    </div>
+    <div class="form-group">
+      <button type="submit" class="btn btn-primary">Logout</button>
+    </div>
+    <div class="form-group">
+      <label>Synopsis</label>
+      <textarea id="logoutSynopsis" class="form-control" readonly=""></textarea>
+    </div>
+    <div class="form-group">
+      <label>Result</label>
+      <textarea id="logoutResult" class="form-control" readonly=""></textarea>
+    </div>
+  </form>
   <script>
 
 function getRedirectURI() {
@@ -105,6 +121,29 @@ function onSubmitFinishAuthorization(e) {
   });
 }
 
+function setupLogoutSynopsis() {
+  var synopsisTextArea = document.getElementById("logoutSynopsis");
+  var funcExpr = "skygear.authui.logout";
+  var s = stringifyFunctionCall(funcExpr);
+  synopsisTextArea.value = s;
+}
+
+function onSubmitLogout(e) {
+  e.preventDefault();
+  e.stopPropagation();
+
+  var redirectURI = getRedirectURI();
+  var resultTextArea = document.getElementById("logoutResult");
+  skygear.authui.logout({
+    redirectURI: redirectURI,
+  }).then(function() {
+    resultTextArea.value = "OK";
+  }, function(e) {
+    console.log(e);
+    resultTextArea.value = JSON.stringify(e);
+  });
+}
+
 skygear.configure({
   appEndpoint: "__SKYGEAR_APP_ENDPOINT__",
   authEndpoint: "__SKYGEAR_AUTH_ENDPOINT__",
@@ -114,6 +153,7 @@ skygear.configure({
 }).then(function() {
   setupStartAuthorizationSynopsis();
   setupFinishAuthorizationSynopsis();
+  setupLogoutSynopsis();
 }, function(e) {
   console.error(e);
 });

--- a/packages/example/src/authui.html
+++ b/packages/example/src/authui.html
@@ -60,7 +60,7 @@ function getRedirectURI() {
 
 function setupStartAuthorizationSynopsis() {
   var synopsisTextArea = document.getElementById("startAuthorizationSynopsis");
-  var funcExpr = "skygear.auth.startAuthorization";
+  var funcExpr = "skygear.authui.startAuthorization";
   var redirectURI = getRedirectURI();
   var s = stringifyFunctionCall(funcExpr, {
     redirectURI: redirectURI,
@@ -74,7 +74,7 @@ function onSubmitStartAuthorization(e) {
 
   var resultTextArea = document.getElementById("startAuthorizationResult");
   var redirectURI = getRedirectURI();
-  skygear.auth.startAuthorization({
+  skygear.authui.startAuthorization({
     redirectURI: redirectURI
   }).then(function() {
     resultTextArea.value = "OK";
@@ -86,7 +86,7 @@ function onSubmitStartAuthorization(e) {
 
 function setupFinishAuthorizationSynopsis() {
   var synopsisTextArea = document.getElementById("finishAuthorizationSynopsis");
-  var funcExpr = "skygear.auth.finishAuthorization";
+  var funcExpr = "skygear.authui.finishAuthorization";
   var s = stringifyFunctionCall(funcExpr);
   synopsisTextArea.value = s;
 }
@@ -97,7 +97,7 @@ function onSubmitFinishAuthorization(e) {
 
   var resultTextArea = document.getElementById("finishAuthorizationResult");
 
-  skygear.auth.finishAuthorization().then(function(result) {
+  skygear.authui.finishAuthorization().then(function(result) {
     resultTextArea.value = JSON.stringify(result);
   }, function(e) {
     console.log(e);

--- a/packages/skygear-core/src/container.ts
+++ b/packages/skygear-core/src/container.ts
@@ -1014,6 +1014,7 @@ export abstract class OIDCContainer<T extends BaseAPIClient> {
       const endSessionEndpoint = `${config.end_session_endpoint}${encodeQuery(
         query
       )}`;
+      await this.auth._clearSession();
       window.location.href = endSessionEndpoint;
     }
   }

--- a/packages/skygear-core/src/types.ts
+++ b/packages/skygear-core/src/types.ts
@@ -702,6 +702,7 @@ export interface _OIDCConfiguration {
   claims_supported: string;
   code_challenge_methods_supported: string;
   revocation_endpoint: string;
+  end_session_endpoint: string;
 }
 
 /**

--- a/packages/skygear-react-native/src/index.ts
+++ b/packages/skygear-react-native/src/index.ts
@@ -228,6 +228,23 @@ export class ReactNativeOIDCContainer<
   async openURL(url: string): Promise<void> {
     await openURL(url);
   }
+
+  /**
+   * Logout.
+   *
+   * @remarks
+   * If `force` parameter is set to `true`, all potential errors (e.g. network
+   * error) would be ignored.
+   *
+   * @param options - Logout options
+   */
+  async logout(
+    options: {
+      force?: boolean;
+    } = {}
+  ): Promise<void> {
+    return this._logout(options);
+  }
 }
 
 /**

--- a/packages/skygear-web/src/container.ts
+++ b/packages/skygear-web/src/container.ts
@@ -137,6 +137,26 @@ export class WebOIDCContainer<T extends WebAPIClient> extends OIDCContainer<T> {
   async finishAuthorization(): Promise<{ user: User; state?: string }> {
     return this._finishAuthorization(window.location.href);
   }
+
+  /**
+   * Logout.
+   *
+   * @remarks
+   * If `force` parameter is set to `true`, all potential errors (e.g. network
+   * error) would be ignored.
+   *
+   * `redirectURI` will be used only for the first party app
+   *
+   * @param options - Logout options
+   */
+  async logout(
+    options: {
+      force?: boolean;
+      redirectURI?: string;
+    } = {}
+  ): Promise<void> {
+    return this._logout(options);
+  }
 }
 
 /**


### PR DESCRIPTION
refs #554 

Discussion:
For first party app, logout function will bring user to end_session_endpoint and redirect back to the app after logout. At this moment, the current user state of SDK is not cleared yet.  Do we need something like `finishLogout`? `end_session_endpoint` will only redirect back to the app only when logout success, so the only `finishLogout` function will do is clear session, and it will be used by first party app only.  Or maybe we should only expose the `clearSession` function for the user, so user should call `clearSession` in their after logout screen? thought?
