### PR TITLE
Don't reject promise if user cancel the authorization window

### DIFF
--- a/packages/skygear-react-native/ios/SGSkygearReactNative.m
+++ b/packages/skygear-react-native/ios/SGSkygearReactNative.m
@@ -207,18 +207,18 @@ RCT_EXPORT_METHOD(openAuthorizeURL:(NSURL *)url
                                                                             callbackURLScheme:scheme
                                                                             completionHandler:^(NSURL *url, NSError *error) {
             if (error) {
-                if (self.openURLReject) {
+                BOOL isUserCancelled = ([[error domain] isEqualToString:ASWebAuthenticationSessionErrorDomain] &&
+                [error code] == ASWebAuthenticationSessionErrorCodeCanceledLogin);
+                if (!isUserCancelled && self.openURLReject) {
                     self.openURLReject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", url], error);
-                    self.openURLResolve = nil;
-                    self.openURLReject = nil;
                 }
             } else {
                 if (self.openURLResolve) {
                     self.openURLResolve([url absoluteString]);
-                    self.openURLResolve = nil;
-                    self.openURLReject = nil;
                 }
             }
+            self.openURLResolve = nil;
+            self.openURLReject = nil;
             self.asSession = nil;
         }];
         if (@available(iOS 13.0, *)) {
@@ -230,18 +230,18 @@ RCT_EXPORT_METHOD(openAuthorizeURL:(NSURL *)url
                                                                       callbackURLScheme:scheme
                                                                       completionHandler:^(NSURL *url, NSError *error) {
             if (error) {
-                if (self.openURLReject) {
+                BOOL isUserCancelled = ([[error domain] isEqualToString:SFAuthenticationErrorDomain] &&
+                [error code] == SFAuthenticationErrorCanceledLogin);
+                if (!isUserCancelled && self.openURLReject) {
                     self.openURLReject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", url], error);
-                    self.openURLResolve = nil;
-                    self.openURLReject = nil;
                 }
             } else {
                 if (self.openURLResolve) {
                     self.openURLResolve([url absoluteString]);
-                    self.openURLResolve = nil;
-                    self.openURLReject = nil;
                 }
             }
+            self.openURLResolve = nil;
+            self.openURLReject = nil;
             self.sfSession = nil;
         }];
         [self.sfSession start];


### PR DESCRIPTION
refs #573

We decided not to call reject when user cancel because there is no way
for us to detect the cancel in some of the platform (iOS <= 10 and
android). Developer also need to handle if user leave the app during the
authorization. So the expected behavior of authorization should be:

1. promise will be resolved when authorization success
2. promise will be rejected if there is problem
3. promise will never settle if user cancel or leave the app